### PR TITLE
Add keyboard shortcut for manual PR checks

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -159,6 +159,26 @@ browserApi.alarms.onAlarm.addListener((alarm) => {
   }
 });
 
+if (browserApi.commands && browserApi.commands.onCommand) {
+  browserApi.commands.onCommand.addListener((command) => {
+    if (command === "check-now") {
+      processEvents()
+        .then((result) => {
+          if (!result || result.skipped) {
+            console.debug("Shortcut check skipped because username is not configured.");
+          } else {
+            console.debug(
+              `Shortcut check processed events; notifications sent: ${result.notificationsSent}`
+            );
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to process events from shortcut", error);
+        });
+    }
+  });
+}
+
 browserApi.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message && message.type === "refresh") {
     (async () => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -18,6 +18,14 @@
     "https://api.github.com/*",
     "<all_urls>"
   ],
+  "commands": {
+    "check-now": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+."
+      },
+      "description": "Manually check for ready pull requests"
+    }
+  },
   "browser_specific_settings": {
     "gecko": {
       "id": "pr-ready-notifier@example.com"


### PR DESCRIPTION
## Summary
- define a browser command with a suggested shortcut to check for ready pull requests on demand
- handle the command in the background script to reuse the existing polling logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7a071545c8333be741a2aa659f5ac