### PR TITLE
Add cancel control for task timeline overlay

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 
 const API=(typeof browser!=='undefined')?browser:chrome;
-const DEFAULTS={strictOrder:true,showTimeline:true,debugLogs:false,openTaskEnabled:true,openTaskDelaySec:1,openTaskSound:true,openTaskNewWindow:true,openTaskFocus:true,openTaskUseHistory:true,openTaskOnlyJustNow:true,createEnabled:true,createDelaySec:1,createSound:true,viewEnabled:true,viewDelaySec:1,viewSound:true,viewCloseEnabled:false,viewCloseDelaySec:2,mergeEnabled:false,mergeDelaySec:3,mergeSound:true,mergeCloseEnabled:false,mergeCloseDelaySec:2,confirmEnabled:false,confirmDelaySec:3,confirmSound:true,approvedMergeUrls:[],seenTaskIds:[],currentTaskId:null,currentFlow:'idle',taskHistory:{},taskFlows:{}};
+const DEFAULTS={strictOrder:true,showTimeline:true,debugLogs:false,openTaskEnabled:true,openTaskDelaySec:1,openTaskSound:true,openTaskNewWindow:true,openTaskFocus:true,openTaskUseHistory:true,openTaskOnlyJustNow:true,createEnabled:true,createDelaySec:1,createSound:true,viewEnabled:true,viewDelaySec:1,viewSound:true,viewCloseEnabled:false,viewCloseDelaySec:2,mergeEnabled:false,mergeDelaySec:3,mergeSound:true,mergeCloseEnabled:false,mergeCloseDelaySec:2,confirmEnabled:false,confirmDelaySec:3,confirmSound:true,approvedMergeUrls:[],seenTaskIds:[],currentTaskId:null,currentFlow:'idle',taskHistory:{},taskFlows:{},dismissedTaskIds:[]};
 const APPROVAL_TTL_MS=600000; const now=()=>Date.now();
 const getAll=()=>new Promise(r=>{try{API.storage.local.get(DEFAULTS,r);}catch(e){r({...DEFAULTS});}});
 const setObj=(o)=>new Promise(r=>API.storage.local.set(o,()=>r(true)));
@@ -8,11 +8,12 @@ API.runtime.onMessage.addListener((m,s,reply)=>{
   if(!m||!m.type) return;
   const ok=(x={})=>reply&&reply({ok:true, ...x});
   if(m.type==='GET_SETTINGS') return getAll().then(c=>ok({settings:c})), true;
-  if(m.type==='RESET_FLOW') return setObj({approvedMergeUrls:[],currentTaskId:null,currentFlow:'idle',taskFlows:{}}).then(ok), true;
+  if(m.type==='RESET_FLOW') return setObj({approvedMergeUrls:[],currentTaskId:null,currentFlow:'idle',taskFlows:{},dismissedTaskIds:[]}).then(ok), true;
   if(m.type==='GET_SHARED_FLOW'){
     const {taskId,url}=m;
     return getAll().then(c=>{
       const flows=c.taskFlows||{};
+      const dismissed=new Set(c.dismissedTaskIds||[]);
       let record=null;
       if(taskId && flows[taskId]) record=flows[taskId];
       if(!record && url){
@@ -22,7 +23,11 @@ API.runtime.onMessage.addListener((m,s,reply)=>{
           return list.some(u=>url.startsWith(u));
         })||null;
       }
-      if(!record) return ok({taskId:taskId||null,flow:'idle',steps:{}});
+      if(!record){
+        if(taskId && dismissed.has(taskId)) return ok({taskId:null,flow:'idle',steps:{},dismissedTaskId:taskId});
+        return ok({taskId:taskId||null,flow:'idle',steps:{}});
+      }
+      dismissed.delete(record.taskId);
       return ok({taskId:record.taskId||taskId||null,flow:record.flow||'idle',title:record.title||'',steps:record.steps||{}});
     }), true;
   }
@@ -48,7 +53,9 @@ API.runtime.onMessage.addListener((m,s,reply)=>{
       if(step) hist.steps={...(hist.steps||{}),[step]:true};
       hist.lastTs=now();
       history[taskId]=hist;
-      return setObj({currentTaskId:taskId,currentFlow:record.flow,taskHistory:history,taskFlows:flows}).then(ok);
+      const dismissed=new Set(c.dismissedTaskIds||[]);
+      if(record.flow && record.flow!=='idle') dismissed.delete(taskId);
+      return setObj({currentTaskId:taskId,currentFlow:record.flow,taskHistory:history,taskFlows:flows,dismissedTaskIds:[...dismissed]}).then(ok);
     }), true;
   }
   if(m.type==='GET_TASK_HISTORY') return getAll().then(c=>ok({history:c.taskHistory||{}})), true;
@@ -79,7 +86,9 @@ API.runtime.onMessage.addListener((m,s,reply)=>{
       flows[taskId]=record;
       const history={...(c.taskHistory||{})};
       history[taskId]={title:record.title||'',steps:{...(record.steps||{})},firstTs:history[taskId]?history[taskId].firstTs:now(),lastTs:now()};
-      return setObj({currentTaskId:taskId,currentFlow:'taskOpened',taskFlows:flows,taskHistory:history}).then(ok);
+      const dismissed=new Set(c.dismissedTaskIds||[]);
+      dismissed.delete(taskId);
+      return setObj({currentTaskId:taskId,currentFlow:'taskOpened',taskFlows:flows,taskHistory:history,dismissedTaskIds:[...dismissed]}).then(ok);
     }), true;
   }
   if(m.type==='VIEW_PR_READY'){
@@ -109,7 +118,9 @@ API.runtime.onMessage.addListener((m,s,reply)=>{
           record.flow='viewed';
           record.steps={...(record.steps||{}),viewed:true};
           record.updatedAt=now();
-          setObj({taskFlows:flows,taskHistory:history,currentTaskId:id,currentFlow:'viewed'});
+          const dismissed=new Set(cc.dismissedTaskIds||[]);
+          dismissed.delete(id);
+          setObj({taskFlows:flows,taskHistory:history,currentTaskId:id,currentFlow:'viewed',dismissedTaskIds:[...dismissed]});
         }
       });
       if(c.viewCloseEnabled && typeof tabId==='number'){
@@ -152,7 +163,9 @@ API.runtime.onMessage.addListener((m,s,reply)=>{
         hist.steps={...(hist.steps||{}),merged:true};
         hist.lastTs=now();
         history[id]=hist;
-        setObj({taskFlows:flows,taskHistory:history,currentTaskId:id,currentFlow:'merged'});
+        const dismissed=new Set(cc.dismissedTaskIds||[]);
+        dismissed.delete(id);
+        setObj({taskFlows:flows,taskHistory:history,currentTaskId:id,currentFlow:'merged',dismissedTaskIds:[...dismissed]});
       });
     }), true;
   }
@@ -183,8 +196,26 @@ API.runtime.onMessage.addListener((m,s,reply)=>{
         hist.steps={...(hist.steps||{}),confirmed:true};
         hist.lastTs=now();
         history[id]=hist;
-        setObj({taskFlows:flows,taskHistory:history,currentTaskId:id,currentFlow:'confirmed'});
+        const dismissed=new Set(cc.dismissedTaskIds||[]);
+        dismissed.delete(id);
+        setObj({taskFlows:flows,taskHistory:history,currentTaskId:id,currentFlow:'confirmed',dismissedTaskIds:[...dismissed]});
       });
+    }), true;
+  }
+  if(m.type==='CLEAR_TASK_FLOW'){
+    const {taskId}=m;
+    if(!taskId) return ok({error:'missingTask'});
+    return getAll().then(c=>{
+      const flows={...(c.taskFlows||{})};
+      delete flows[taskId];
+      const dismissed=new Set(c.dismissedTaskIds||[]);
+      dismissed.add(taskId);
+      let {currentTaskId,currentFlow}=c;
+      if(currentTaskId===taskId){
+        currentTaskId=null;
+        currentFlow='idle';
+      }
+      return setObj({taskFlows:flows,currentTaskId,currentFlow,dismissedTaskIds:[...dismissed]}).then(ok);
     }), true;
   }
 });


### PR DESCRIPTION
## Summary
- add a cancel button to the floating task timeline so users can stop tracking a task
- persist cancelled task IDs in the background script so the overlay stays hidden until the flow restarts
- keep non-interactive parts of the overlay click-through while making the cancel control accessible

## Testing
- not run (extension change)


------
https://chatgpt.com/codex/tasks/task_e_68d82816ecec8333a99e28289c9584de