### PR TITLE
Respect view delay before notifying background

### DIFF
--- a/content.js
+++ b/content.js
@@ -395,7 +395,9 @@ async function handleViewPROpen(){
   const key='_autoPrViewHandled';
   if((link&&link.dataset[key]==='1')||(btn&&btn.dataset[key]==='1')) return;
   if(link) link.dataset[key]='1'; if(btn) btn.dataset[key]='1';
-  await sendMessage('VIEW_PR_READY',{url,taskId});
+  const delayMs=Math.max(0,Math.min(60000,Math.round(Number(s.viewDelaySec)*1000)||0));
+  if(delayMs>0) await new Promise(r=>setTimeout(r,delayMs));
+  await sendMessage('VIEW_PR_READY',{url,taskId,delayMs,delayElapsed:true});
   await setSharedFlow('viewed',{step:'viewed',taskId,url});
   highlightTimeline(taskId,'viewed');
 }


### PR DESCRIPTION
## Summary
- wait for the configured View PR delay inside the content script before signaling the background page
- let the background page open the PR tab immediately after the content-side wait while keeping close-tab timing in sync with the effective delay

## Testing
- not run (extension manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68d851f7de188333a363cb1327935b31