### PR TITLE
Update View PR strict order handling

### DIFF
--- a/content.js
+++ b/content.js
@@ -384,9 +384,15 @@ async function handleViewPROpen(){
   if(!taskId) return;
   if(taskId && !shared.taskId) shared.taskId=taskId;
   mountTimeline(shared,s);
+  const shouldRecordManualCreate=s.strictOrder&&!s.createEnabled&&!(shared.steps&&shared.steps.created);
+  if(shouldRecordManualCreate){
+    await setSharedFlow('created',{step:'created',taskId});
+    shared.flow='created';
+    shared.steps={...(shared.steps||{}),created:true};
+  }
   highlightTimeline(taskId,shared.flow);
   if(shared.steps&&shared.steps.viewed) return;
-  if(s.strictOrder && shared.flow!=='created') return;
+  if(s.strictOrder && s.createEnabled && shared.flow!=='created') return;
   const c=qsAll('a,button,summary').filter(el=>visible(el)&&TEXTS.VIEW.test((el.innerText||el.textContent||'').trim()));
   const link=c.find(el=>el.tagName==='A'&&el.href);
   const btn=c.find(el=>el.tagName!=='A');


### PR DESCRIPTION
## Summary
- allow the View PR automation to proceed when strict order is enabled but Create PR automation is disabled
- record a created milestone before logging the viewed step so the task timeline stays consistent during manual create flows

## Testing
- not run (extension logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68d8cd4f6f8083338d176f93601456fb