### PR TITLE
Stop displaying timeline overlay on GitHub

### DIFF
--- a/content.js
+++ b/content.js
@@ -215,6 +215,10 @@ function mountTimeline(shared,settings){
   }
   const maybeSettings=settings?Promise.resolve(settings):getSettings();
   maybeSettings.then(s=>{
+    if(location.hostname.includes('github.com')){
+      clearTimeline();
+      return;
+    }
     if(!s.showTimeline){
       clearTimeline();
       return;


### PR DESCRIPTION
## Summary
- stop mounting the task timeline overlay when browsing on GitHub
- ensure any existing timeline element is cleared on GitHub pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d4a8e7208333868082141cbb62ed