### PR TITLE
Add initial Firefox WebExtension scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Sample WebExtension
+
+This repository contains a minimal Firefox-compatible WebExtension with a background service worker and an interactive popup.
+
+## Project structure
+
+- `manifest.json` – extension manifest referencing the background service worker and popup UI
+- `src/background.js` – background service worker with installation logging and a sample message handler
+- `src/popup.html` – popup UI shown when the toolbar button is clicked
+- `src/popup.js` – popup script that sends a message to the background worker
+- `src/popup.css` – basic styles for the popup
+
+## Load the extension in Firefox
+
+1. Clone this repository and ensure all files are available locally.
+2. Open Firefox and navigate to `about:debugging` in the address bar.
+3. Select **This Firefox** in the sidebar.
+4. Click **Load Temporary Add-on...**.
+5. In the file picker, choose the `manifest.json` file from this project.
+6. A new toolbar button labelled **Sample Extension** appears. Click it to open the popup and test the ping/pong interaction.
+
+The extension remains installed until you restart Firefox. Repeat the steps above to load it again after restarting the browser.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Sample WebExtension",
+  "version": "1.0.0",
+  "description": "A starter WebExtension with background script and popup.",
+  "action": {
+    "default_title": "Sample Extension",
+    "default_popup": "src/popup.html"
+  },
+  "background": {
+    "service_worker": "src/background.js",
+    "type": "module"
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,13 @@
+console.log("Sample WebExtension background service worker loaded.");
+
+browser.runtime.onInstalled.addListener(() => {
+  console.log("Sample WebExtension installed and ready.");
+});
+
+browser.runtime.onMessage.addListener(async (message) => {
+  if (message?.type === "ping") {
+    console.log("Received ping from popup.");
+    return { type: "pong", timestamp: Date.now() };
+  }
+  return undefined;
+});

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,32 @@
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-width: 240px;
+  margin: 0;
+  padding: 16px;
+  background-color: #f9fafb;
+  color: #1f2933;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+button {
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #2563eb;
+  border-radius: 0.375rem;
+  background: #3b82f6;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+button:hover {
+  background: #2563eb;
+}
+
+output {
+  min-height: 1.25rem;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sample Extension Popup</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Sample WebExtension</h1>
+      <p>This popup confirms the extension is loaded.</p>
+      <button id="ping">Send ping</button>
+      <output id="response" aria-live="polite"></output>
+    </main>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,20 @@
+const responseOutput = document.getElementById("response");
+const pingButton = document.getElementById("ping");
+
+async function sendPing() {
+  responseOutput.textContent = "Sending message...";
+  try {
+    const response = await browser.runtime.sendMessage({ type: "ping" });
+    if (response?.type === "pong") {
+      const formatted = new Date(response.timestamp).toLocaleTimeString();
+      responseOutput.textContent = `Received pong at ${formatted}`;
+    } else {
+      responseOutput.textContent = "Unexpected response from background.";
+    }
+  } catch (error) {
+    console.error("Failed to send ping", error);
+    responseOutput.textContent = "Failed to reach background script.";
+  }
+}
+
+pingButton.addEventListener("click", sendPing);


### PR DESCRIPTION
## Summary
- add a manifest that registers a background service worker and popup action
- implement a background script that logs lifecycle events and replies to ping messages
- create a popup UI with scripts and styles plus documentation for loading the extension in Firefox

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8db0d65e883338ec6bdb0df2896be