### PR TITLE
Document update rules and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.0.1 - 2024-07-06
+- Added project update rules documenting version bump expectations and change logging requirements.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ This repository contains a minimal Firefox-compatible WebExtension with a backgr
 6. A new toolbar button labelled **Sample Extension** appears. Click it to open the popup and test the ping/pong interaction.
 
 The extension remains installed until you restart Firefox. Repeat the steps above to load it again after restarting the browser.
+
+## Project update rules
+
+To keep the project history consistent:
+
+1. Document every change in `CHANGELOG.md` with a brief description of what was updated.
+2. Update the `version` field in `manifest.json` whenever the project changes.
+   - For routine or small adjustments, increment the patch number (`x.x.+1`).
+   - For new functions or other major additions, increment the minor number (`x.+1.x`).

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Sample WebExtension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A starter WebExtension with background script and popup.",
   "browser_action": {
     "default_title": "Sample Extension",


### PR DESCRIPTION
## Summary
- document project update rules in the README so future changes include notes and version bumps
- add a changelog to capture updates starting with the new documentation change
- bump the extension manifest version to 1.0.1 to reflect the documentation update

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dd17c9c08333ad0152e4dabb8e28