### PR TITLE
Rename extension to codex-autorun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 1.0.2 - 2024-07-06
+- Renamed the extension and associated UI text to **codex-autorun**.
+
 ## 1.0.1 - 2024-07-06
 - Added project update rules documenting version bump expectations and change logging requirements.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Sample WebExtension
+# codex-autorun
 
-This repository contains a minimal Firefox-compatible WebExtension with a background script and an interactive popup.
+This repository contains the codex-autorun Firefox-compatible WebExtension with a background script and an interactive popup.
 
 ## Project structure
 
-- `manifest.json` – extension manifest referencing the background script and popup UI
+- `manifest.json` – extension manifest referencing the background script and popup UI for codex-autorun
 - `src/background.js` – background script with installation logging and a sample message handler
 - `src/popup.html` – popup UI shown when the toolbar button is clicked
 - `src/popup.js` – popup script that sends a message to the background worker
@@ -17,7 +17,7 @@ This repository contains a minimal Firefox-compatible WebExtension with a backgr
 3. Select **This Firefox** in the sidebar.
 4. Click **Load Temporary Add-on...**.
 5. In the file picker, choose the `manifest.json` file from this project.
-6. A new toolbar button labelled **Sample Extension** appears. Click it to open the popup and test the ping/pong interaction.
+6. A new toolbar button labelled **codex-autorun** appears. Click it to open the popup and test the ping/pong interaction.
 
 The extension remains installed until you restart Firefox. Repeat the steps above to load it again after restarting the browser.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 2,
-  "name": "Sample WebExtension",
-  "version": "1.0.1",
-  "description": "A starter WebExtension with background script and popup.",
+  "name": "codex-autorun",
+  "version": "1.0.2",
+  "description": "The codex-autorun WebExtension with background script and popup.",
   "browser_action": {
-    "default_title": "Sample Extension",
+    "default_title": "codex-autorun",
     "default_popup": "src/popup.html"
   },
   "background": {

--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,7 @@
-console.log("Sample WebExtension background service worker loaded.");
+console.log("codex-autorun background service worker loaded.");
 
 browser.runtime.onInstalled.addListener(() => {
-  console.log("Sample WebExtension installed and ready.");
+  console.log("codex-autorun installed and ready.");
 });
 
 browser.runtime.onMessage.addListener(async (message) => {

--- a/src/popup.html
+++ b/src/popup.html
@@ -2,13 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Sample Extension Popup</title>
+    <title>codex-autorun popup</title>
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
     <main>
-      <h1>Sample WebExtension</h1>
-      <p>This popup confirms the extension is loaded.</p>
+      <h1>codex-autorun</h1>
+      <p>This popup confirms the codex-autorun extension is loaded.</p>
       <button id="ping">Send ping</button>
       <output id="response" aria-live="polite"></output>
     </main>


### PR DESCRIPTION
## Summary
- rename the extension metadata and UI strings to codex-autorun
- refresh the README to reflect the codex-autorun branding
- bump the manifest version to 1.0.2 and document the change in the changelog

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8ddddefb48333b5e8a33e17571663