### PR TITLE
Add Codex task watcher and task history popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.1.0 - 2025-09-28
+- Added a Codex page content watcher that scans every three seconds for the "working" status indicator square and reports detected tasks to the background script.
+- Persist detected task history in extension storage and expose it through the popup UI.
+- Rebuilt the popup to show the tracked task history with refresh controls and improved styling.
+
 ## 1.0.2 - 2024-07-06
 - Renamed the extension and associated UI text to **codex-autorun**.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # codex-autorun
 
-This repository contains the codex-autorun Firefox-compatible WebExtension with a background script and an interactive popup.
+This repository contains the codex-autorun Firefox-compatible WebExtension with a background script, a Codex page watcher, and an interactive popup for reviewing detected tasks.
 
 ## Project structure
 
 - `manifest.json` – extension manifest referencing the background script and popup UI for codex-autorun
-- `src/background.js` – background script with installation logging and a sample message handler
+- `src/background.js` – background script that persists detected task history and responds to popup/content requests
+- `src/codexWatcher.js` – content script injected into `https://chatgpt.com/codex*` that scans for the "working" square indicator every three seconds and reports new tasks
 - `src/popup.html` – popup UI shown when the toolbar button is clicked
-- `src/popup.js` – popup script that sends a message to the background worker
-- `src/popup.css` – basic styles for the popup
+- `src/popup.js` – popup script that renders the tracked history and lets the user refresh it on demand
+- `src/popup.css` – styles used by the popup
 
 ## Load the extension in Firefox
 
@@ -17,7 +18,7 @@ This repository contains the codex-autorun Firefox-compatible WebExtension with 
 3. Select **This Firefox** in the sidebar.
 4. Click **Load Temporary Add-on...**.
 5. In the file picker, choose the `manifest.json` file from this project.
-6. A new toolbar button labelled **codex-autorun** appears. Click it to open the popup and test the ping/pong interaction.
+6. A new toolbar button labelled **codex-autorun** appears. Click it to open the popup and review the tracked task history.
 
 The extension remains installed until you restart Firefox. Repeat the steps above to load it again after restarting the browser.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "The codex-autorun WebExtension with background script and popup.",
+  "permissions": ["storage"],
   "browser_action": {
     "default_title": "codex-autorun",
     "default_popup": "src/popup.html",
@@ -11,5 +12,12 @@
   "background": {
     "scripts": ["src/background.js"],
     "persistent": false
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chatgpt.com/codex*"],
+      "js": ["src/codexWatcher.js"],
+      "run_at": "document_idle"
+    }
+  ]
 }

--- a/src/background.js
+++ b/src/background.js
@@ -1,13 +1,123 @@
-console.log("codex-autorun background service worker loaded.");
+const runtime =
+  typeof browser !== "undefined" && browser?.runtime
+    ? browser.runtime
+    : chrome.runtime;
+const storage =
+  typeof browser !== "undefined" && browser?.storage
+    ? browser.storage
+    : chrome.storage;
 
-browser.runtime.onInstalled.addListener(() => {
+const HISTORY_KEY = "codexTaskHistory";
+
+console.log("codex-autorun background service worker loaded.");
+runtime.onInstalled.addListener(() => {
   console.log("codex-autorun installed and ready.");
 });
 
-browser.runtime.onMessage.addListener(async (message) => {
-  if (message?.type === "ping") {
-    console.log("Received ping from popup.");
-    return { type: "pong", timestamp: Date.now() };
+function storageGet(key) {
+  if (!storage?.local) {
+    return Promise.resolve(undefined);
   }
-  return undefined;
+  try {
+    const result = storage.local.get(key);
+    if (result && typeof result.then === "function") {
+      return result.then((data) => data?.[key]);
+    }
+  } catch (error) {
+    console.error("Failed to get storage value", error);
+  }
+  return new Promise((resolve) => {
+    storage.local.get(key, (data) => {
+      if (runtime?.lastError) {
+        console.error("Storage get error", runtime.lastError);
+        resolve(undefined);
+        return;
+      }
+      resolve(data?.[key]);
+    });
+  });
+}
+
+function storageSet(key, value) {
+  if (!storage?.local) {
+    return Promise.resolve();
+  }
+  const payload = { [key]: value };
+  try {
+    const result = storage.local.set(payload);
+    if (result && typeof result.then === "function") {
+      return result;
+    }
+  } catch (error) {
+    console.error("Failed to set storage value", error);
+  }
+  return new Promise((resolve) => {
+    storage.local.set(payload, () => {
+      if (runtime?.lastError) {
+        console.error("Storage set error", runtime.lastError);
+      }
+      resolve();
+    });
+  });
+}
+
+async function appendHistory(task) {
+  if (!task?.id) {
+    return;
+  }
+  const history = (await storageGet(HISTORY_KEY)) ?? [];
+  const exists = history.some((entry) => entry.id === task.id);
+  if (exists) {
+    return;
+  }
+  const entry = {
+    id: task.id,
+    name: task.name ?? `Task ${task.id}`,
+    url: task.url ?? null,
+    startedAt: task.startedAt ?? new Date().toISOString(),
+    status: task.status ?? "working",
+  };
+  const nextHistory = [entry, ...history].slice(0, 200);
+  await storageSet(HISTORY_KEY, nextHistory);
+  console.log("Tracked codex task", entry);
+}
+
+async function getHistory() {
+  return (await storageGet(HISTORY_KEY)) ?? [];
+}
+
+runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+
+  if (message.type === "ping") {
+    console.log("Received ping from popup.");
+    sendResponse?.({ type: "pong", timestamp: Date.now() });
+    return false;
+  }
+
+  if (message.type === "square-detected") {
+    appendHistory(message.task).then(
+      () => sendResponse?.({ type: "ack" }),
+      (error) => {
+        console.error("Failed to append task history", error);
+        sendResponse?.({ type: "error", message: String(error) });
+      },
+    );
+    return true;
+  }
+
+  if (message.type === "get-history") {
+    getHistory().then(
+      (history) => sendResponse?.({ type: "history", history }),
+      (error) => {
+        console.error("Failed to load task history", error);
+        sendResponse?.({ type: "error", message: String(error) });
+      },
+    );
+    return true;
+  }
+
+  return false;
 });

--- a/src/codexWatcher.js
+++ b/src/codexWatcher.js
@@ -1,0 +1,170 @@
+const runtime =
+  typeof browser !== "undefined" && browser?.runtime
+    ? browser.runtime
+    : chrome?.runtime;
+
+const trackedTasks = new Map();
+const MIN_SQUARE_SIZE = 6;
+const MAX_SQUARE_SIZE = 24;
+
+function isTransparentColor(color) {
+  if (!color || color === "transparent") {
+    return true;
+  }
+  const rgbaMatch = color.match(/rgba?\(([^)]+)\)/i);
+  if (!rgbaMatch) {
+    return false;
+  }
+  const parts = rgbaMatch[1].split(",").map((value) => value.trim());
+  if (parts.length === 4) {
+    const alpha = parseFloat(parts[3]);
+    return Number.isFinite(alpha) ? alpha === 0 : false;
+  }
+  if (parts.length === 3) {
+    return parts.every((value) => value === "0" || value === "0%" || value === "0.0");
+  }
+  return false;
+}
+
+function isSquareIndicator(element) {
+  if (!element || typeof element.getBoundingClientRect !== "function") {
+    return false;
+  }
+  const rect = element.getBoundingClientRect();
+  if (!rect.width || !rect.height) {
+    return false;
+  }
+  if (rect.width < MIN_SQUARE_SIZE || rect.height < MIN_SQUARE_SIZE) {
+    return false;
+  }
+  if (rect.width > MAX_SQUARE_SIZE || rect.height > MAX_SQUARE_SIZE) {
+    return false;
+  }
+  const aspectDifference = Math.abs(rect.width - rect.height);
+  if (aspectDifference > Math.max(2, Math.min(rect.width, rect.height) * 0.25)) {
+    return false;
+  }
+  const style = window.getComputedStyle(element);
+  const hasBackground = style && !isTransparentColor(style.backgroundColor);
+  const borderWidth = parseFloat(style?.borderWidth ?? "0");
+  const hasBorder = Number.isFinite(borderWidth) && borderWidth > 0.2 && !isTransparentColor(style?.borderColor ?? "transparent");
+  return hasBackground || hasBorder;
+}
+
+function findIndicatorElement(container) {
+  if (!container) {
+    return null;
+  }
+  const directMatch = container.querySelector(
+    '[data-testid*="indicator" i], [data-testid*="status" i], [aria-label*="working" i], [title*="working" i]',
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+  const candidates = container.querySelectorAll("span, div, i, svg, button");
+  for (const element of candidates) {
+    if (isSquareIndicator(element)) {
+      return element;
+    }
+  }
+  return null;
+}
+
+function extractTaskId(href) {
+  if (!href) {
+    return null;
+  }
+  try {
+    const url = new URL(href, window.location.origin);
+    const match = url.pathname.match(/\/codex\/tasks\/([^/]+)/i);
+    return match ? match[1] : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function extractTaskName(container, link) {
+  const candidate =
+    container?.querySelector("h1, h2, h3, h4, [data-testid*='title' i], strong") ?? link;
+  if (candidate?.textContent) {
+    const text = candidate.textContent.replace(/\s+/g, " ").trim();
+    if (text) {
+      return text;
+    }
+  }
+  const fallback = link?.textContent ?? container?.textContent;
+  return fallback ? fallback.replace(/\s+/g, " ").trim() : null;
+}
+
+function extractTaskUrl(link) {
+  if (!link) {
+    return null;
+  }
+  if (link.href) {
+    return link.href;
+  }
+  const href = link.getAttribute("href");
+  if (href) {
+    try {
+      return new URL(href, window.location.origin).toString();
+    } catch (error) {
+      return href;
+    }
+  }
+  return null;
+}
+
+function notifyBackground(task) {
+  if (!runtime?.sendMessage) {
+    return;
+  }
+  try {
+    const result = runtime.sendMessage({ type: "square-detected", task });
+    if (result && typeof result.catch === "function") {
+      result.catch(() => {});
+    }
+  } catch (error) {
+    console.warn("codex-autorun: failed to notify background", error);
+  }
+}
+
+function scanForTasks() {
+  const links = Array.from(document.querySelectorAll('a[href*="/codex/tasks/"]'));
+  const seenIds = new Set();
+
+  for (const link of links) {
+    const taskId = extractTaskId(link.getAttribute("href") || link.href);
+    if (!taskId || seenIds.has(taskId)) {
+      continue;
+    }
+    seenIds.add(taskId);
+    const container =
+      link.closest('[data-testid*="task" i], article, li, section, div') ??
+      link.parentElement ??
+      link;
+    const indicator = findIndicatorElement(container);
+    if (indicator) {
+      if (!trackedTasks.has(taskId)) {
+        const name = extractTaskName(container, link) ?? `Task ${taskId}`;
+        const url = extractTaskUrl(link);
+        const startedAt = new Date().toISOString();
+        trackedTasks.set(taskId, { name, url, startedAt });
+        notifyBackground({ id: taskId, name, url, startedAt, status: "working" });
+      }
+    } else if (trackedTasks.has(taskId)) {
+      trackedTasks.delete(taskId);
+    }
+  }
+
+  for (const trackedId of Array.from(trackedTasks.keys())) {
+    if (!seenIds.has(trackedId)) {
+      trackedTasks.delete(trackedId);
+    }
+  }
+}
+
+if (!window.__codexSquareWatcherInitialized) {
+  window.__codexSquareWatcherInitialized = true;
+  scanForTasks();
+  setInterval(scanForTasks, 3000);
+}

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,6 +1,10 @@
-body {
+:root {
+  color-scheme: light;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  min-width: 240px;
+}
+
+body {
+  min-width: 320px;
   margin: 0;
   padding: 16px;
   background-color: #f9fafb;
@@ -10,23 +14,156 @@ body {
 main {
   display: flex;
   flex-direction: column;
+  gap: 1rem;
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
+}
+
+.banner h1 {
+  font-size: 1.125rem;
+  margin: 0;
+}
+
+.description {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
 }
 
 button {
   cursor: pointer;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.75rem;
   border: 1px solid #2563eb;
-  border-radius: 0.375rem;
+  border-radius: 0.5rem;
   background: #3b82f6;
   color: #ffffff;
   font-weight: 600;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
-button:hover {
+button:hover:not(:disabled) {
   background: #2563eb;
 }
 
-output {
+button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.history {
+  background: #ffffff;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  padding: 0.75rem;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+}
+
+.history-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.history-heading h2 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0c4a6e;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.empty {
+  margin: 0;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.history-item:hover {
+  border-color: #cbd5f5;
+  background: #eef2ff;
+}
+
+.task-name {
+  font-weight: 600;
+  color: #1e3a8a;
+  text-decoration: none;
+}
+
+.task-name:hover {
+  text-decoration: underline;
+}
+
+.task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: #475569;
+}
+
+.task-id {
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.375rem;
+  background: #ede9fe;
+  color: #5b21b6;
+  font-weight: 500;
+}
+
+.task-started {
+  color: #1f2937;
+}
+
+.task-status {
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.375rem;
+  background: #dcfce7;
+  color: #166534;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+#error {
   min-height: 1.25rem;
+  color: #b91c1c;
+  font-size: 0.8rem;
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -7,10 +7,22 @@
   </head>
   <body>
     <main>
-      <h1>codex-autorun</h1>
-      <p>This popup confirms the codex-autorun extension is loaded.</p>
-      <button id="ping">Send ping</button>
-      <output id="response" aria-live="polite"></output>
+      <header class="banner">
+        <h1>codex-autorun</h1>
+        <button id="refresh" type="button" title="Refresh history">Refresh</button>
+      </header>
+      <p class="description">
+        Monitoring for Codex tasks that show the working indicator square.
+      </p>
+      <section class="history" aria-labelledby="history-title">
+        <div class="history-heading">
+          <h2 id="history-title">Task history</h2>
+          <span id="history-count" class="count-badge" hidden></span>
+        </div>
+        <p id="empty-state" class="empty">No tasks detected yet.</p>
+        <ol id="history" class="history-list"></ol>
+      </section>
+      <output id="error" role="status" aria-live="polite"></output>
     </main>
     <script type="module" src="popup.js"></script>
   </body>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,20 +1,126 @@
-const responseOutput = document.getElementById("response");
-const pingButton = document.getElementById("ping");
+const refreshButton = document.getElementById("refresh");
+const historyList = document.getElementById("history");
+const emptyState = document.getElementById("empty-state");
+const errorOutput = document.getElementById("error");
+const countBadge = document.getElementById("history-count");
 
-async function sendPing() {
-  responseOutput.textContent = "Sending message...";
-  try {
-    const response = await browser.runtime.sendMessage({ type: "ping" });
-    if (response?.type === "pong") {
-      const formatted = new Date(response.timestamp).toLocaleTimeString();
-      responseOutput.textContent = `Received pong at ${formatted}`;
-    } else {
-      responseOutput.textContent = "Unexpected response from background.";
+function sendMessage(message) {
+  if (typeof browser !== "undefined" && browser?.runtime?.sendMessage) {
+    return browser.runtime.sendMessage(message);
+  }
+  if (typeof chrome !== "undefined" && chrome?.runtime?.sendMessage) {
+    return new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(message, (response) => {
+        const error = chrome.runtime.lastError;
+        if (error) {
+          reject(new Error(error.message));
+          return;
+        }
+        resolve(response);
+      });
+    });
+  }
+  return Promise.reject(new Error("Runtime messaging is unavailable."));
+}
+
+function formatTimestamp(timestamp) {
+  if (!timestamp) {
+    return "Unknown";
+  }
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function renderHistory(history) {
+  historyList.innerHTML = "";
+  const tasks = Array.isArray(history) ? history : [];
+
+  if (!tasks.length) {
+    emptyState.hidden = false;
+    countBadge.hidden = true;
+    return;
+  }
+
+  emptyState.hidden = true;
+  countBadge.hidden = false;
+  countBadge.textContent = String(tasks.length);
+
+  for (const task of tasks) {
+    const item = document.createElement("li");
+    item.className = "history-item";
+
+    const title = document.createElement(task?.url ? "a" : "span");
+    title.className = "task-name";
+    title.textContent = task?.name ?? task?.id ?? "Unknown task";
+    if (task?.url) {
+      title.href = task.url;
+      title.target = "_blank";
+      title.rel = "noopener noreferrer";
     }
-  } catch (error) {
-    console.error("Failed to send ping", error);
-    responseOutput.textContent = "Failed to reach background script.";
+
+    const meta = document.createElement("div");
+    meta.className = "task-meta";
+
+    const idBadge = document.createElement("span");
+    idBadge.className = "task-id";
+    if (task?.id) {
+      idBadge.textContent = task.id;
+    } else {
+      idBadge.textContent = "unknown";
+    }
+
+    const startedTime = document.createElement("time");
+    startedTime.className = "task-started";
+    if (task?.startedAt) {
+      startedTime.dateTime = task.startedAt;
+    }
+    startedTime.textContent = formatTimestamp(task?.startedAt);
+
+    const status = document.createElement("span");
+    status.className = "task-status";
+    const statusLabel = task?.status ? String(task.status) : "working";
+    status.textContent = statusLabel.charAt(0).toUpperCase() + statusLabel.slice(1);
+
+    meta.append(idBadge, startedTime, status);
+    item.append(title, meta);
+    historyList.append(item);
   }
 }
 
-pingButton.addEventListener("click", sendPing);
+async function loadHistory() {
+  errorOutput.textContent = "";
+  try {
+    const response = await sendMessage({ type: "get-history" });
+    if (response?.type === "history") {
+      renderHistory(response.history);
+      return;
+    }
+    if (response?.type === "error") {
+      throw new Error(response.message ?? "Unknown background error");
+    }
+    throw new Error("Unexpected response from background script.");
+  } catch (error) {
+    console.error("Failed to load history", error);
+    emptyState.hidden = true;
+    countBadge.hidden = true;
+    historyList.innerHTML = "";
+    errorOutput.textContent = `Unable to load history: ${error.message}`;
+  }
+}
+
+refreshButton?.addEventListener("click", () => {
+  refreshButton.disabled = true;
+  loadHistory().finally(() => {
+    refreshButton.disabled = false;
+  });
+});
+
+window.addEventListener("DOMContentLoaded", () => {
+  loadHistory();
+});


### PR DESCRIPTION
## Summary
- add a Codex content script that scans every three seconds for the working status square and reports matching tasks
- persist detected task history in the background script and expose it through the popup
- refresh the popup UI to display tracked task history with styling improvements and a manual refresh control

## Testing
- not run (extension changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d8e14a13e883338c7477b801717bd9