### PR TITLE
Add Create PR workflow actions to popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.1.1 - 2025-09-28
+- Added popup actions to open ready tasks, trigger the "Create PR" workflow, and mark the status as PR created.
+- Introduced new styling for task actions and status badges.
+- Granted the extension permission to open task links in new tabs.
+
 # 1.1.0 - 2025-09-28
 - Added a Codex page content watcher that scans every three seconds for the "working" status indicator square and reports detected tasks to the background script.
 - Persist detected task history in extension storage and expose it through the popup UI.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This repository contains the codex-autorun Firefox-compatible WebExtension with 
 - `src/popup.js` – popup script that renders the tracked history and lets the user refresh it on demand
 - `src/popup.css` – styles used by the popup
 
+## Popup workflow
+
+When a tracked task leaves the "working" state, the popup now highlights it as **Ready** and provides a **Create PR** action. Clicking the button opens the original task link in a new tab and marks the stored status as **PR created** so you can track which tasks already have pull requests in flight. All other tasks expose an **Open task** action for quick access to their Codex links.
+
 ## Load the extension in Firefox
 
 1. Clone this repository and ensure all files are available locally.

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The codex-autorun WebExtension with background script and popup.",
-  "permissions": ["storage"],
+  "permissions": ["storage", "tabs"],
   "browser_action": {
     "default_title": "codex-autorun",
     "default_popup": "src/popup.html",

--- a/src/background.js
+++ b/src/background.js
@@ -158,5 +158,16 @@ runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
+  if (message.type === "update-task-status") {
+    updateHistory(message.task).then(
+      () => sendResponse?.({ type: "ack" }),
+      (error) => {
+        console.error("Failed to update task status", error);
+        sendResponse?.({ type: "error", message: String(error) });
+      },
+    );
+    return true;
+  }
+
   return false;
 });

--- a/src/popup.css
+++ b/src/popup.css
@@ -107,10 +107,11 @@ button:disabled {
   overflow-y: auto;
 }
 
+
 .history-item {
   display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   padding: 0.5rem;
   border-radius: 0.5rem;
   border: 1px solid #e2e8f0;
@@ -130,6 +131,13 @@ button:disabled {
 
 .task-name:hover {
   text-decoration: underline;
+}
+
+.task-content {
+  flex: 1 1 60%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
 }
 
 .task-meta {
@@ -158,8 +166,41 @@ button:disabled {
   background: #dcfce7;
   color: #166534;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.task-status--ready {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.task-status--pr-created {
+  background: #e0e7ff;
+  color: #4338ca;
+}
+
+.task-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-left: auto;
+}
+
+.task-action {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+}
+
+.task-action.view-task {
+  border-color: #94a3b8;
+  background: #e2e8f0;
+  color: #1f2937;
+}
+
+.task-action.view-task:hover:not(:disabled) {
+  background: #cbd5f5;
+  border-color: #94a3b8;
 }
 
 #error {

--- a/src/popup.js
+++ b/src/popup.js
@@ -37,6 +37,84 @@ function formatTimestamp(timestamp) {
   }).format(date);
 }
 
+function formatStatusLabel(status) {
+  if (!status) {
+    return "Working";
+  }
+  const normalized = String(status).trim();
+  if (!normalized) {
+    return "Working";
+  }
+  if (normalized.toLowerCase() === "pr-created") {
+    return "PR created";
+  }
+  const words = normalized
+    .replace(/[_-]+/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => {
+      if (word.length <= 2) {
+        return word.toUpperCase();
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    });
+  return words.length ? words.join(" ") : "Working";
+}
+
+function openTaskInNewTab(url) {
+  if (!url) {
+    return Promise.resolve();
+  }
+  if (typeof browser !== "undefined" && browser?.tabs?.create) {
+    return browser.tabs.create({ url }).then(() => {});
+  }
+  if (typeof chrome !== "undefined" && chrome?.tabs?.create) {
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.tabs.create({ url }, () => {
+          const error = chrome.runtime?.lastError;
+          if (error) {
+            reject(new Error(error.message));
+            return;
+          }
+          resolve();
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+  return Promise.resolve();
+}
+
+async function handleCreatePr(button, task) {
+  if (!task?.id) {
+    return;
+  }
+  errorOutput.textContent = "";
+  button.disabled = true;
+  try {
+    if (task?.url) {
+      await openTaskInNewTab(task.url);
+    }
+    await sendMessage({
+      type: "update-task-status",
+      task: {
+        id: task.id,
+        status: "pr-created",
+        completedAt: new Date().toISOString(),
+      },
+    });
+    await loadHistory();
+  } catch (error) {
+    console.error("Failed to create PR", error);
+    errorOutput.textContent = `Unable to update task: ${error.message}`;
+  } finally {
+    button.disabled = false;
+  }
+}
+
 function renderHistory(history) {
   historyList.innerHTML = "";
   const tasks = Array.isArray(history) ? history : [];
@@ -55,6 +133,9 @@ function renderHistory(history) {
     const item = document.createElement("li");
     item.className = "history-item";
 
+    const content = document.createElement("div");
+    content.className = "task-content";
+
     const title = document.createElement(task?.url ? "a" : "span");
     title.className = "task-name";
     title.textContent = task?.name ?? task?.id ?? "Unknown task";
@@ -63,6 +144,7 @@ function renderHistory(history) {
       title.target = "_blank";
       title.rel = "noopener noreferrer";
     }
+    content.append(title);
 
     const meta = document.createElement("div");
     meta.className = "task-meta";
@@ -84,11 +166,50 @@ function renderHistory(history) {
 
     const status = document.createElement("span");
     status.className = "task-status";
-    const statusLabel = task?.status ? String(task.status) : "working";
-    status.textContent = statusLabel.charAt(0).toUpperCase() + statusLabel.slice(1);
+    const statusValueRaw = task?.status ? String(task.status) : "working";
+    const statusKey = statusValueRaw.toLowerCase();
+    status.textContent = formatStatusLabel(statusValueRaw);
+    status.classList.add(
+      `task-status--${statusKey.replace(/[^a-z0-9]+/g, "-")}`,
+    );
 
     meta.append(idBadge, startedTime, status);
-    item.append(title, meta);
+    content.append(meta);
+    item.append(content);
+
+    const actions = document.createElement("div");
+    actions.className = "task-actions";
+    let hasActions = false;
+
+    if (statusKey === "ready" && task?.url) {
+      const createPrButton = document.createElement("button");
+      createPrButton.type = "button";
+      createPrButton.className = "task-action create-pr";
+      createPrButton.textContent = "Create PR";
+      createPrButton.addEventListener("click", () => handleCreatePr(createPrButton, task));
+      actions.append(createPrButton);
+      hasActions = true;
+    }
+
+    if (task?.url && statusKey !== "ready") {
+      const viewTaskButton = document.createElement("button");
+      viewTaskButton.type = "button";
+      viewTaskButton.className = "task-action view-task";
+      viewTaskButton.textContent = "Open task";
+      viewTaskButton.addEventListener("click", () => {
+        openTaskInNewTab(task.url).catch((error) => {
+          console.error("Failed to open task", error);
+          errorOutput.textContent = `Unable to open task: ${error.message}`;
+        });
+      });
+      actions.append(viewTaskButton);
+      hasActions = true;
+    }
+
+    if (hasActions) {
+      item.append(actions);
+    }
+
     historyList.append(item);
   }
 }


### PR DESCRIPTION
## Summary
- add popup actions that open ready tasks, trigger the Create PR workflow, and record the PR-created status
- restyle the popup list items and status badges to accommodate the new actions
- bump the extension version, request the tabs permission, and document the updated workflow

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8e8503e4c8333bff43de4d5f8e116