### PR TITLE
Add status label to task entries

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -170,6 +170,17 @@ button:disabled {
   letter-spacing: normal;
 }
 
+.task-status-container {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.task-status-label {
+  font-weight: 500;
+  color: #334155;
+}
+
 .task-status--ready {
   background: #fef3c7;
   color: #92400e;

--- a/src/popup.js
+++ b/src/popup.js
@@ -194,16 +194,26 @@ function renderHistory(history) {
     }
     startedTime.textContent = formatTimestamp(task?.startedAt);
 
-    const status = document.createElement("span");
-    status.className = "task-status";
     const statusValueRaw = task?.status ? String(task.status) : "working";
     const statusKey = statusValueRaw.toLowerCase();
+
+    const statusContainer = document.createElement("span");
+    statusContainer.className = "task-status-container";
+
+    const statusLabel = document.createElement("span");
+    statusLabel.className = "task-status-label";
+    statusLabel.textContent = "Status:";
+
+    const status = document.createElement("span");
+    status.className = "task-status";
     status.textContent = formatStatusLabel(statusValueRaw);
     status.classList.add(
       `task-status--${statusKey.replace(/[^a-z0-9]+/g, "-")}`,
     );
 
-    meta.append(idBadge, startedTime, status);
+    statusContainer.append(statusLabel, status);
+
+    meta.append(idBadge, startedTime, statusContainer);
     content.append(meta);
     item.append(content);
 


### PR DESCRIPTION
## Summary
- show a "Status" label next to each task's status badge in the popup
- style the new label so it aligns with the existing task metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8f66ee25883338da6847ef94d5e77