### PR TITLE
Adjust task status layout

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -140,6 +140,14 @@ button:disabled {
   gap: 0.4rem;
 }
 
+.task-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .task-meta {
   display: flex;
   flex-wrap: wrap;

--- a/src/popup.js
+++ b/src/popup.js
@@ -166,6 +166,9 @@ function renderHistory(history) {
     const content = document.createElement("div");
     content.className = "task-content";
 
+    const header = document.createElement("div");
+    header.className = "task-header";
+
     const title = document.createElement(task?.url ? "a" : "span");
     title.className = "task-name";
     title.textContent = task?.name ?? task?.id ?? "Unknown task";
@@ -174,7 +177,7 @@ function renderHistory(history) {
       title.target = "_blank";
       title.rel = "noopener noreferrer";
     }
-    content.append(title);
+    header.append(title);
 
     const meta = document.createElement("div");
     meta.className = "task-meta";
@@ -213,7 +216,10 @@ function renderHistory(history) {
 
     statusContainer.append(statusLabel, status);
 
-    meta.append(idBadge, startedTime, statusContainer);
+    header.append(statusContainer);
+    content.append(header);
+
+    meta.append(idBadge, startedTime);
     content.append(meta);
     item.append(content);
 


### PR DESCRIPTION
## Summary
- show each task's status next to the task title in the history list
- add styling for the new header layout to keep the status aligned with the task

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d8f8437c6c833381bae193c8ecb858