### PR TITLE
Hide redundant working status text

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -200,23 +200,28 @@ function renderHistory(history) {
     const statusValueRaw = task?.status ? String(task.status) : "working";
     const statusKey = statusValueRaw.toLowerCase();
 
-    const statusContainer = document.createElement("span");
-    statusContainer.className = "task-status-container";
+    const shouldDisplayStatus =
+      statusKey !== "working" && statusKey !== "working on your task";
 
-    const statusLabel = document.createElement("span");
-    statusLabel.className = "task-status-label";
-    statusLabel.textContent = "Status:";
+    if (shouldDisplayStatus) {
+      const statusContainer = document.createElement("span");
+      statusContainer.className = "task-status-container";
 
-    const status = document.createElement("span");
-    status.className = "task-status";
-    status.textContent = formatStatusLabel(statusValueRaw);
-    status.classList.add(
-      `task-status--${statusKey.replace(/[^a-z0-9]+/g, "-")}`,
-    );
+      const statusLabel = document.createElement("span");
+      statusLabel.className = "task-status-label";
+      statusLabel.textContent = "Status:";
 
-    statusContainer.append(statusLabel, status);
+      const status = document.createElement("span");
+      status.className = "task-status";
+      status.textContent = formatStatusLabel(statusValueRaw);
+      status.classList.add(
+        `task-status--${statusKey.replace(/[^a-z0-9]+/g, "-")}`,
+      );
 
-    header.append(statusContainer);
+      statusContainer.append(statusLabel, status);
+
+      header.append(statusContainer);
+    }
     content.append(header);
 
     meta.append(idBadge, startedTime);


### PR DESCRIPTION
## Summary
- suppress the status pill for tasks with the default "working" message so the task row no longer shows the redundant text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fff131f88333bfaf34aeb8eb541c