### PR TITLE
Allow extension to run on chatgpt.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "codex-autorun",
   "version": "1.1.4",
   "description": "The codex-autorun WebExtension with background script and popup.",
-  "permissions": ["storage", "tabs"],
+  "permissions": ["storage", "tabs", "https://chatgpt.com/*"],
   "browser_action": {
     "default_title": "codex-autorun",
     "default_popup": "src/popup.html",
@@ -15,7 +15,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://chatgpt.com/codex*"],
+      "matches": ["https://chatgpt.com/*"],
       "js": ["src/codexWatcher.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary
- grant the extension host permissions for https://chatgpt.com/*
- allow the content script to match every page on chatgpt.com

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d901198bf083338b03da0c17a6f3ff