### PR TITLE
Replace toolbar icons with SVG assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.1.6 - 2025-09-28
+- Replaced the PNG toolbar icons with equivalent SVG assets so the repository no longer depends on binary files.
+
+# 1.1.5 - 2025-09-28
+- Added Firefox toolbar icon assets and wired them up in the manifest so the button renders again.
+
 # 1.1.4 - 2025-09-28
 - Restore automatic handling of ready Codex tasks by opening them in a new tab and marking them as PR created without opening the popup.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,23 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": ["storage", "tabs", "https://chatgpt.com/*"],
+  "icons": {
+    "16": "src/icons/icon-16.svg",
+    "32": "src/icons/icon-32.svg",
+    "48": "src/icons/icon-48.svg"
+  },
   "browser_action": {
     "default_title": "codex-autorun",
     "default_popup": "src/popup.html",
-    "default_area": "navbar"
+    "default_area": "navbar",
+    "default_icon": {
+      "16": "src/icons/icon-16.svg",
+      "32": "src/icons/icon-32.svg",
+      "48": "src/icons/icon-48.svg"
+    }
   },
   "background": {
     "scripts": ["src/background.js"],

--- a/src/icons/icon-16.svg
+++ b/src/icons/icon-16.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="grad16" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3f51b5" />
+      <stop offset="100%" stop-color="#1a237e" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="16" height="16" rx="3" fill="url(#grad16)" />
+  <path d="M4.5 4.5h3.25a2.75 2.75 0 010 5.5H6.5v1.5H4.5zM6.5 8.5h1.25a.75.75 0 000-1.5H6.5z" fill="#ffffff"/>
+</svg>

--- a/src/icons/icon-32.svg
+++ b/src/icons/icon-32.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="grad32" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3f51b5" />
+      <stop offset="100%" stop-color="#1a237e" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="30" height="30" rx="5" fill="url(#grad32)" />
+  <path d="M9 9h7a5 5 0 010 10h-3v4H9zM13 15h3a1 1 0 000-2h-3z" fill="#ffffff"/>
+</svg>

--- a/src/icons/icon-48.svg
+++ b/src/icons/icon-48.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="grad48" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3f51b5" />
+      <stop offset="100%" stop-color="#1a237e" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="44" height="44" rx="8" fill="url(#grad48)" />
+  <path d="M13 13h10a7 7 0 010 14h-5v7h-5zM18 21h5a2 2 0 000-4h-5z" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace the PNG toolbar icons with SVG equivalents to avoid committing binary assets
- point the manifest icon declarations at the new SVG files and bump the extension version to 1.1.6
- note the icon format change in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9034a6fa08333a6e0b7c662e7eded