### PR TITLE
Serve toolbar icons from SVG assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.7 - 2025-09-28
+- Added explicit 19 px/38 px SVG toolbar icons in the manifest so the browser menu button renders without requiring binary assets.
+
 # 1.1.6 - 2025-09-28
 - Replaced the PNG toolbar icons with equivalent SVG assets so the repository no longer depends on binary files.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": ["storage", "tabs", "https://chatgpt.com/*"],
   "icons": {
@@ -15,7 +15,9 @@
     "default_area": "navbar",
     "default_icon": {
       "16": "src/icons/icon-16.svg",
+      "19": "src/icons/icon-19.svg",
       "32": "src/icons/icon-32.svg",
+      "38": "src/icons/icon-38.svg",
       "48": "src/icons/icon-48.svg"
     }
   },

--- a/src/icons/icon-19.svg
+++ b/src/icons/icon-19.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="grad19" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3f51b5" />
+      <stop offset="100%" stop-color="#1a237e" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="30" height="30" rx="5" fill="url(#grad19)" />
+  <path d="M9 9h7a5 5 0 010 10h-3v4H9zM13 15h3a1 1 0 000-2h-3z" fill="#ffffff"/>
+</svg>

--- a/src/icons/icon-38.svg
+++ b/src/icons/icon-38.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="grad38" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3f51b5" />
+      <stop offset="100%" stop-color="#1a237e" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="44" height="44" rx="8" fill="url(#grad38)" />
+  <path d="M13 13h10a7 7 0 010 14h-5v7h-5zM18 21h5a2 2 0 000-4h-5z" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- point the extension manifest back to SVG icons and add explicit 19px/38px toolbar entries so the menu button renders without PNGs
- document the SVG toolbar icon fix in the 1.1.7 changelog entry

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d90b2f5ca48333b0aae18cc046ad00