### PR TITLE
Restore toolbar icon visibility with SVG assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.8 - 2025-09-28
+- Added dedicated SVG toolbar icons so the codex-autorun button is visible in the menu bar again.
+
 # 1.1.7 - 2025-09-28
 - Added explicit 19 px/38 px SVG toolbar icons in the manifest so the browser menu button renders without requiring binary assets.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,14 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": ["storage", "tabs", "https://chatgpt.com/*"],
   "icons": {
     "16": "src/icons/icon-16.png",
     "32": "src/icons/icon-32.png",
-    "48": "src/icons/icon-48.png"
+    "48": "src/icons/icon-48.png",
+    "128": "src/icons/icon-128.png"
   },
   "browser_action": {
     "default_title": "codex-autorun",
@@ -15,9 +16,9 @@
     "default_area": "navbar",
     "default_icon": {
       "16": "src/icons/icon-16.png",
-      "19": "src/icons/icon-19.png",
+      "19": "src/icons/icon-19.svg",
       "32": "src/icons/icon-32.png",
-      "38": "src/icons/icon-38.png",
+      "38": "src/icons/icon-38.svg",
       "48": "src/icons/icon-48.png"
     }
   },

--- a/src/icons/icon-19.svg
+++ b/src/icons/icon-19.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 0 24 24">
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#0a84ff" />
+  <path
+    fill="#ffffff"
+    d="M10.27 15.35 7.4 12.48l-1.41 1.41 4.28 4.28 7.07-7.07-1.41-1.41z"
+  />
+</svg>

--- a/src/icons/icon-38.svg
+++ b/src/icons/icon-38.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 24 24">
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#0a84ff" />
+  <path
+    fill="#ffffff"
+    d="M10.27 15.35 7.4 12.48l-1.41 1.41 4.28 4.28 7.07-7.07-1.41-1.41z"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- add dedicated SVG toolbar icons so the codex-autorun button reappears in the browser menu bar
- point the manifest at the new assets, add a 128px listing icon, and bump the extension version to 1.1.8
- document the change in the changelog

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d92473b6488333be0364bed7185426