### PR TITLE
Refresh tracked task names while Codex works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.9 - 2025-09-28
+- Refresh task names while Codex is still working so the popup stays aligned with the UI.
+
 # 1.1.8 - 2025-09-28
 - Added dedicated SVG toolbar icons so the codex-autorun button is visible in the menu bar again.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": ["storage", "tabs", "https://chatgpt.com/*"],
   "icons": {

--- a/src/codexWatcher.js
+++ b/src/codexWatcher.js
@@ -570,6 +570,44 @@ function scanForTasks() {
         const task = { name: storedName, url, startedAt, status: "working" };
         trackedTasks.set(taskId, task);
         notifyBackground({ id: taskId, ...task });
+      } else {
+        const tracked = trackedTasks.get(taskId);
+        let updated = false;
+
+        const extractedName = extractTaskName(container, link);
+        if (extractedName) {
+          rememberTaskName(taskId, extractedName);
+          const storedName = knownTaskNames.get(taskId) ?? extractedName;
+          if (storedName && storedName !== tracked?.name) {
+            if (tracked) {
+              tracked.name = storedName;
+            }
+            updated = true;
+          }
+        }
+
+        const url = extractTaskUrl(link);
+        if (url && tracked && url !== tracked.url) {
+          tracked.url = url;
+          updated = true;
+        }
+
+        if (updated && tracked) {
+          const updatePayload = {
+            id: taskId,
+            status: tracked.status ?? "working",
+          };
+          if (tracked.name) {
+            updatePayload.name = tracked.name;
+          }
+          if (tracked.url) {
+            updatePayload.url = tracked.url;
+          }
+          if (tracked.startedAt) {
+            updatePayload.startedAt = tracked.startedAt;
+          }
+          notifyTaskUpdate(updatePayload);
+        }
       }
     } else if (trackedTasks.has(taskId)) {
       const tracked = trackedTasks.get(taskId);


### PR DESCRIPTION
## Summary
- refresh tracked task entries while Codex is still working so the popup matches the latest title
- bump the extension to version 1.1.9 and document the change

## Testing
- not run (browser extension changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d92635d61c8333acad0251d1a49cb2