### PR TITLE
Add debuggpt.tools host permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.10 - 2025-09-28
+- Inject the Codex watcher on debuggpt.tools so new tasks appear in the history again.
+
 # 1.1.9 - 2025-09-28
 - Refresh task names while Codex is still working so the popup stays aligned with the UI.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,14 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "The codex-autorun WebExtension with background script and popup.",
-  "permissions": ["storage", "tabs", "https://chatgpt.com/*"],
+  "permissions": [
+    "storage",
+    "tabs",
+    "https://chatgpt.com/*",
+    "https://debuggpt.tools/*"
+  ],
   "icons": {
     "16": "src/icons/icon-16.png",
     "32": "src/icons/icon-32.png",
@@ -28,7 +33,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://chatgpt.com/*"],
+      "matches": ["https://chatgpt.com/*", "https://debuggpt.tools/*"],
       "js": ["src/codexWatcher.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary
- allow the extension to run on debuggpt.tools alongside chatgpt.com
- document the change in the changelog and bump the patch version

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d92956cd488333a8eb1631c472bffe