### PR TITLE
Add toolbar icon sizes to manifest icon list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.11 - 2025-09-28
+- Added toolbar icon sizes to the manifest icon map so Safari keeps the codex-autorun button visible in the menu bar.
+
 # 1.1.10 - 2025-09-28
 - Inject the Codex watcher on debuggpt.tools so new tasks appear in the history again.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",
@@ -11,7 +11,9 @@
   ],
   "icons": {
     "16": "src/icons/icon-16.png",
+    "19": "src/icons/icon-19.png",
     "32": "src/icons/icon-32.png",
+    "38": "src/icons/icon-38.png",
     "48": "src/icons/icon-48.png",
     "128": "src/icons/icon-128.png"
   },


### PR DESCRIPTION
## Summary
- include the 19 px and 38 px toolbar assets in the manifest icon map so Safari keeps the codex-autorun button visible
- bump the extension version and document the change in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d92c2a41c48333a06eb2a8c117639c