### PR TITLE
Show task status in history list

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -176,6 +176,7 @@ button:disabled {
   font-weight: 600;
   text-transform: none;
   letter-spacing: normal;
+  white-space: nowrap;
 }
 
 .task-status-container {
@@ -194,9 +195,41 @@ button:disabled {
   color: #92400e;
 }
 
+.task-status--working,
+.task-status--working-on-your-task {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
 .task-status--pr-created {
   background: #e0e7ff;
   color: #4338ca;
+}
+
+.task-status--pending,
+.task-status--queued {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.task-status--completed,
+.task-status--done,
+.task-status--success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.task-status--failed,
+.task-status--error,
+.task-status--cancelled,
+.task-status--canceled {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.task-status--unknown {
+  background: #e2e8f0;
+  color: #475569;
 }
 
 .task-actions {

--- a/src/popup.js
+++ b/src/popup.js
@@ -198,30 +198,25 @@ function renderHistory(history) {
     startedTime.textContent = formatTimestamp(task?.startedAt);
 
     const statusValueRaw = task?.status ? String(task.status) : "working";
-    const statusKey = statusValueRaw.toLowerCase();
+    const statusKey = statusValueRaw.toLowerCase().trim();
+    const statusClassSuffix =
+      statusKey.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
 
-    const shouldDisplayStatus =
-      statusKey !== "working" && statusKey !== "working on your task";
+    const statusContainer = document.createElement("span");
+    statusContainer.className = "task-status-container";
 
-    if (shouldDisplayStatus) {
-      const statusContainer = document.createElement("span");
-      statusContainer.className = "task-status-container";
+    const statusLabel = document.createElement("span");
+    statusLabel.className = "task-status-label";
+    statusLabel.textContent = "Status:";
 
-      const statusLabel = document.createElement("span");
-      statusLabel.className = "task-status-label";
-      statusLabel.textContent = "Status:";
+    const status = document.createElement("span");
+    status.className = "task-status";
+    status.textContent = formatStatusLabel(statusValueRaw);
+    status.classList.add(`task-status--${statusClassSuffix}`);
 
-      const status = document.createElement("span");
-      status.className = "task-status";
-      status.textContent = formatStatusLabel(statusValueRaw);
-      status.classList.add(
-        `task-status--${statusKey.replace(/[^a-z0-9]+/g, "-")}`,
-      );
+    statusContainer.append(statusLabel, status);
 
-      statusContainer.append(statusLabel, status);
-
-      header.append(statusContainer);
-    }
+    header.append(statusContainer);
     content.append(header);
 
     meta.append(idBadge, startedTime);


### PR DESCRIPTION
## Summary
- always render a status label for every task entry in the popup history
- normalize status class names so styles apply to any status value and add variants for common states

## Testing
- Manual verification of popup layout

------
https://chatgpt.com/codex/tasks/task_e_68d92e5398f88333840f7234e8e4763f