### PR TITLE
Add merged status handling to popup history

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -237,6 +237,11 @@ button:disabled {
   color: #4338ca;
 }
 
+.task-status--merged {
+  background: #bbf7d0;
+  color: #166534;
+}
+
 .task-actions {
   display: flex;
   flex-direction: column;

--- a/src/popup.js
+++ b/src/popup.js
@@ -7,6 +7,7 @@ const countBadge = document.getElementById("history-count");
 const autoCreatePrTasks = new Set();
 let autoCreatePrQueue = Promise.resolve();
 const lastKnownTaskStatuses = new Map();
+const COMPLETED_STATUS_KEYS = new Set(["ready", "merged"]);
 
 let hasRenderedHistory = false;
 let audioContext;
@@ -338,17 +339,21 @@ function renderHistory(history) {
     startedTime.textContent = formatTimestamp(task?.startedAt);
 
     const statusValueRaw = task?.status ? String(task.status) : "working";
-    const statusKey = statusValueRaw.toLowerCase();
+    const statusKey = statusValueRaw.trim().toLowerCase();
 
     if (task?.id) {
       nextStatuses.set(task.id, statusKey);
       const previousStatus = lastKnownTaskStatuses.get(task.id);
-      if (hasRenderedHistory && statusKey === "ready") {
-        if (previousStatus && previousStatus !== "ready") {
-          shouldPlayCompletionSound = true;
-        } else if (previousStatus === undefined) {
-          shouldPlayCompletionSound = true;
-        }
+      const wasPreviouslyCompleted =
+        previousStatus !== undefined &&
+        COMPLETED_STATUS_KEYS.has(previousStatus);
+
+      if (
+        hasRenderedHistory &&
+        COMPLETED_STATUS_KEYS.has(statusKey) &&
+        !wasPreviouslyCompleted
+      ) {
+        shouldPlayCompletionSound = true;
       }
     }
 


### PR DESCRIPTION
## Summary
- mark merged tasks as completed in the popup so that completion alerts trigger once
- style the merged status badge to distinguish finished tasks

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d97cbb42b48333910c717b319cd414