### PR TITLE
Prevent ready updates from adding new history entries

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -189,6 +189,8 @@ async function appendHistory(task) {
   console.log("Tracked codex task", entry);
 }
 
+const COMPLETED_STATUS_KEYS = new Set(["ready", "pr-created", "merged"]);
+
 async function updateHistory(task) {
   const id = normalizeTaskId(task?.id);
   if (!id) {
@@ -202,6 +204,12 @@ async function updateHistory(task) {
   const index = history.findIndex((entry) => normalizeTaskId(entry?.id) === id);
 
   if (index === -1) {
+    const statusKey = String(task?.status ?? "")
+      .trim()
+      .toLowerCase();
+    if (statusKey && COMPLETED_STATUS_KEYS.has(statusKey)) {
+      return;
+    }
     const sanitizedName = sanitizeTaskName(task?.name);
     const entry = {
       id,
@@ -472,3 +480,20 @@ runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   return false;
 });
+
+if (typeof module !== "undefined" && module?.exports) {
+  module.exports = {
+    appendHistory,
+    updateHistory,
+    getHistory,
+    markTaskClosed,
+    normalizeTaskId,
+    sanitizeTaskName,
+    resolveTaskName,
+    storageGet,
+    storageSet,
+    HISTORY_KEY,
+    CLOSED_TASKS_KEY,
+    COMPLETED_STATUS_KEYS,
+  };
+}

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert";
+
+const store = {};
+const setCalls = [];
+
+global.chrome = {
+  runtime: {
+    lastError: null,
+    onMessage: { addListener() {} },
+    onInstalled: { addListener() {} },
+  },
+  storage: {
+    local: {
+      get(key, callback) {
+        const value = Object.prototype.hasOwnProperty.call(store, key)
+          ? store[key]
+          : undefined;
+        if (typeof callback === "function") {
+          setImmediate(() => callback({ [key]: value }));
+          return;
+        }
+        return Promise.resolve({ [key]: value });
+      },
+      set(payload, callback) {
+        setCalls.push(payload);
+        Object.assign(store, payload);
+        if (typeof callback === "function") {
+          setImmediate(() => callback());
+          return;
+        }
+        return Promise.resolve();
+      },
+    },
+  },
+};
+
+global.browser = undefined;
+
+global.tabs = undefined;
+
+global.console = console;
+
+const backgroundModule = await import("../src/background.js");
+const background = backgroundModule.default ?? backgroundModule;
+
+const { updateHistory, HISTORY_KEY, CLOSED_TASKS_KEY } = background;
+
+test("ready status update for unknown task does not create history entry", async () => {
+  store[HISTORY_KEY] = [
+    { id: "1", name: "Task 1", status: "working" },
+    { id: "2", name: "Task 2", status: "working" },
+    { id: "3", name: "Task 3", status: "working" },
+  ];
+  store[CLOSED_TASKS_KEY] = [];
+  setCalls.length = 0;
+
+  await updateHistory({ id: "999", status: "ready" });
+
+  assert.strictEqual(
+    setCalls.length,
+    0,
+    "No storage writes should occur for completed updates of unknown tasks",
+  );
+  assert.deepStrictEqual(
+    store[HISTORY_KEY],
+    [
+      { id: "1", name: "Task 1", status: "working" },
+      { id: "2", name: "Task 2", status: "working" },
+      { id: "3", name: "Task 3", status: "working" },
+    ],
+    "Existing history should remain unchanged",
+  );
+});


### PR DESCRIPTION
## Summary
- avoid adding new history entries when completed statuses arrive for unknown tasks
- expose background utilities for testing in Node
- add a Node-based test that checks completed updates do not write history

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d9a1e76f748333a915ad9da3c38fab