### PR TITLE
Handle “Committing changes” placeholder task names

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -19,6 +19,7 @@ const CLOSED_TASKS_KEY = "codexClosedTaskIds";
 const IGNORED_NAME_PATTERNS = [
   /working on your task/gi,
   /just now/gi,
+  /committing changes?/gi,
 ];
 
 function sanitizeTaskName(value) {

--- a/src/codexWatcher.js
+++ b/src/codexWatcher.js
@@ -195,6 +195,7 @@ function extractTaskId(href) {
 const IGNORED_TEXT_PATTERNS = [
   /\bworking on your task\b/i,
   /\bjust now\b/i,
+  /\bcommitting changes?\b/i,
   /\b(?:seconds?|minutes?|hours?|days?)\s+ago\b/i,
 ];
 
@@ -257,6 +258,9 @@ function shouldScheduleNameRefresh(name, taskId) {
     return true;
   }
   if (/\bworking on your task\b/i.test(lower)) {
+    return true;
+  }
+  if (/\bcommitting changes?\b/i.test(lower)) {
     return true;
   }
   if (/\bjust now\b/i.test(lower)) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -104,3 +104,16 @@ test("sanitizeTaskName still strips bare repository slugs", () => {
     "Repository-like task names should still resolve to the fallback",
   );
 });
+
+test("sanitizeTaskName strips committing changes placeholder", () => {
+  assert.strictEqual(
+    sanitizeTaskName("Committing changes"),
+    "",
+    "Progress placeholders should be removed from task names",
+  );
+  assert.strictEqual(
+    resolveTaskName("Committing changes", "789"),
+    "Task 789",
+    "Progress placeholders should resolve to the fallback task id",
+  );
+});


### PR DESCRIPTION
## Summary
- treat the "Committing changes" copy as a placeholder that triggers a task name refresh when scraping tasks
- strip the same placeholder in the background script so stored history falls back to real task names
- cover the regression with a unit test for `sanitizeTaskName`

## Testing
- node --test tests/background.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9bb7a0d708333a1b3b9e4a90fe68b