### PR TITLE
Restore SVG toolbar icons for menu bar visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.14 - 2025-09-28
+- Restore the SVG toolbar icons in the manifest so the codex-autorun button reappears in the menu bar.
+
 # 1.1.13 - 2025-09-28
 - Removed the smart check action from the popup and background services.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",
@@ -11,9 +11,9 @@
   ],
   "icons": {
     "16": "src/icons/icon-16.png",
-    "19": "src/icons/icon-19.png",
+    "19": "src/icons/icon-19.svg",
     "32": "src/icons/icon-32.png",
-    "38": "src/icons/icon-38.png",
+    "38": "src/icons/icon-38.svg",
     "48": "src/icons/icon-48.png",
     "128": "src/icons/icon-128.png"
   },
@@ -23,9 +23,9 @@
     "default_area": "navbar",
     "default_icon": {
       "16": "src/icons/icon-16.png",
-      "19": "src/icons/icon-19.png",
+      "19": "src/icons/icon-19.svg",
       "32": "src/icons/icon-32.png",
-      "38": "src/icons/icon-38.png",
+      "38": "src/icons/icon-38.svg",
       "48": "src/icons/icon-48.png"
     }
   },


### PR DESCRIPTION
## Summary
- point the toolbar icon entries in the manifest back to the SVG assets so the browser shows the button again
- bump the extension version to 1.1.14 and document the change in the changelog

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da237001bc833396038d4820fb5e8f