### PR TITLE
Fix toolbar icon by using PNG assets

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,9 +11,9 @@
   ],
   "icons": {
     "16": "src/icons/icon-16.png",
-    "19": "src/icons/icon-19.svg",
+    "19": "src/icons/icon-19.png",
     "32": "src/icons/icon-32.png",
-    "38": "src/icons/icon-38.svg",
+    "38": "src/icons/icon-38.png",
     "48": "src/icons/icon-48.png",
     "128": "src/icons/icon-128.png"
   },
@@ -23,9 +23,9 @@
     "default_area": "navbar",
     "default_icon": {
       "16": "src/icons/icon-16.png",
-      "19": "src/icons/icon-19.svg",
+      "19": "src/icons/icon-19.png",
       "32": "src/icons/icon-32.png",
-      "38": "src/icons/icon-38.svg",
+      "38": "src/icons/icon-38.png",
       "48": "src/icons/icon-48.png"
     }
   },


### PR DESCRIPTION
## Summary
- use PNG assets for the toolbar icon definitions in the manifest
- ensure the extension icon reappears in the browser toolbar menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da254f279c833384186b21fd243282