### PR TITLE
Add settings toggle for pin reminder

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -28,6 +28,23 @@
           your task history.
         </p>
       </section>
+      <section class="options__section" aria-labelledby="pin-reminder-heading">
+        <div class="section-heading">
+          <h2 id="pin-reminder-heading">Pin reminder</h2>
+          <p class="section-description">
+            Choose whether codex-autorun should remind you to pin the toolbar
+            button after updates.
+          </p>
+        </div>
+        <label class="toggle">
+          <input type="checkbox" id="pin-reminder-enabled" />
+          <span class="toggle__label">Show the pin reminder after updates</span>
+        </label>
+        <p class="hint">
+          Turning this off stops codex-autorun from opening the pin reminder
+          page when the extension updates.
+        </p>
+      </section>
       <output
         id="options-status"
         class="options__status"

--- a/src/options.js
+++ b/src/options.js
@@ -4,9 +4,11 @@ import {
   getSettings,
   normalizeSettings,
   setSoundNotificationsEnabled,
+  setPinReminderEnabled,
 } from "./settings.js";
 
 const soundToggle = document.getElementById("sound-enabled");
+const pinReminderToggle = document.getElementById("pin-reminder-enabled");
 const statusOutput = document.getElementById("options-status");
 
 let isInitializing = true;
@@ -41,6 +43,9 @@ function updateForm(settings) {
   if (soundToggle) {
     soundToggle.checked = normalized.soundNotifications.enabled !== false;
   }
+  if (pinReminderToggle) {
+    pinReminderToggle.checked = normalized.pinReminder.enabled !== false;
+  }
 }
 
 async function loadSettingsIntoForm() {
@@ -72,7 +77,24 @@ async function handleSoundToggleChange() {
   }
 }
 
+async function handlePinReminderToggleChange() {
+  if (isInitializing || !pinReminderToggle) {
+    return;
+  }
+  const enabled = pinReminderToggle.checked;
+  setStatus("Saving preferences…");
+  try {
+    await setPinReminderEnabled(enabled);
+    setStatus("Preferences saved.");
+  } catch (error) {
+    console.error("Failed to save pin reminder setting", error);
+    setStatus(`Unable to save changes: ${error.message}`, { isError: true });
+    pinReminderToggle.checked = !enabled;
+  }
+}
+
 soundToggle?.addEventListener("change", handleSoundToggleChange);
+pinReminderToggle?.addEventListener("change", handlePinReminderToggleChange);
 
 document.addEventListener("DOMContentLoaded", () => {
   loadSettingsIntoForm();

--- a/src/pinReminder.html
+++ b/src/pinReminder.html
@@ -140,11 +140,11 @@
         </small>
       </div>
       <p>
-        We'll remind you about pinning after updates unless you choose not to see this message again.
+        We'll remind you about pinning after updates. If you'd prefer not to see
+        this reminder, you can turn it off from the codex-autorun settings page.
       </p>
       <div class="actions">
         <button id="got-it" class="primary">Got it</button>
-        <button id="dismiss" class="secondary">Don't remind me again</button>
       </div>
     </main>
     <script src="pinReminder.js"></script>

--- a/src/pinReminder.js
+++ b/src/pinReminder.js
@@ -1,82 +1,12 @@
-const runtime =
-  typeof browser !== "undefined" && browser?.runtime
-    ? browser.runtime
-    : chrome?.runtime;
-const storage =
-  typeof browser !== "undefined" && browser?.storage
-    ? browser.storage
-    : chrome?.storage;
-
-const PIN_REMINDER_DISMISSED_KEY = "codexPinReminderDismissed";
-
-function storageSet(key, value) {
-  if (!storage?.local?.set) {
-    return Promise.resolve();
-  }
-  const payload = { [key]: value };
-  return new Promise((resolve) => {
-    let settled = false;
-    const finalize = () => {
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
-    };
-
-    try {
-      const result = storage.local.set(payload, () => {
-        if (runtime?.lastError) {
-          console.error(
-            "Failed to persist pin reminder preference",
-            runtime.lastError
-          );
-        }
-        finalize();
-      });
-
-      if (result && typeof result.then === "function") {
-        result
-          .catch((error) => {
-            console.error(
-              "Failed to persist pin reminder preference",
-              error
-            );
-          })
-          .finally(finalize);
-        return;
-      }
-
-      if (storage?.local?.set?.length < 2) {
-        finalize();
-      }
-    } catch (error) {
-      console.error("Failed to persist pin reminder preference", error);
-      finalize();
-    }
-  });
-}
-
-async function markDismissed() {
-  await storageSet(PIN_REMINDER_DISMISSED_KEY, true);
-}
-
 function closeWindow() {
   window.close();
 }
 
 document.addEventListener("DOMContentLoaded", () => {
   const gotItButton = document.getElementById("got-it");
-  const dismissButton = document.getElementById("dismiss");
 
   if (gotItButton) {
     gotItButton.addEventListener("click", () => {
-      closeWindow();
-    });
-  }
-
-  if (dismissButton) {
-    dismissButton.addEventListener("click", async () => {
-      await markDismissed();
       closeWindow();
     });
   }


### PR DESCRIPTION
## Summary
- remove the dismiss option from the pin reminder page and update the copy to point users to settings
- add a pin reminder preference to the options page and persist it alongside the other extension settings
- update the background worker to respect the new setting while still honoring legacy dismissal data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da2cc904648333b986203f1b7cbfa0