### PR TITLE
Add toolbar icon visibility setting

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -15,6 +15,82 @@ const autoProcessingTasks = new Set();
 
 const HISTORY_KEY = "codexTaskHistory";
 const CLOSED_TASKS_KEY = "codexClosedTaskIds";
+const SETTINGS_KEY = "codexSettings";
+
+function resolveActionApi() {
+  try {
+    if (typeof browser !== "undefined") {
+      if (browser?.browserAction) {
+        return browser.browserAction;
+      }
+      if (browser?.action) {
+        return browser.action;
+      }
+    }
+    if (typeof chrome !== "undefined") {
+      if (chrome?.browserAction) {
+        return chrome.browserAction;
+      }
+      if (chrome?.action) {
+        return chrome.action;
+      }
+    }
+  } catch (error) {
+    console.error("Failed to resolve toolbar action API", error);
+  }
+  return null;
+}
+
+const toolbarActionApi = resolveActionApi();
+let toolbarIconVisible = true;
+
+function isToolbarIconVisible(settings) {
+  if (!settings || typeof settings !== "object") {
+    return true;
+  }
+  const toolbar = settings.toolbarIcon;
+  if (toolbar && typeof toolbar === "object" && toolbar.visible !== undefined) {
+    return Boolean(toolbar.visible);
+  }
+  if (settings.showToolbarIcon !== undefined) {
+    return Boolean(settings.showToolbarIcon);
+  }
+  return true;
+}
+
+function updateToolbarIconVisibility(shouldShow) {
+  if (!toolbarActionApi) {
+    return;
+  }
+  const desiredState = shouldShow !== false;
+  if (toolbarIconVisible === desiredState) {
+    return;
+  }
+  toolbarIconVisible = desiredState;
+  try {
+    if (desiredState) {
+      if (typeof toolbarActionApi.enable === "function") {
+        toolbarActionApi.enable();
+      }
+    } else if (typeof toolbarActionApi.disable === "function") {
+      toolbarActionApi.disable();
+    }
+  } catch (error) {
+    console.error("Failed to update toolbar icon visibility", error);
+  }
+}
+
+async function initializeToolbarIconVisibility() {
+  if (!toolbarActionApi) {
+    return;
+  }
+  try {
+    const settings = await storageGet(SETTINGS_KEY);
+    updateToolbarIconVisibility(isToolbarIconVisible(settings));
+  } catch (error) {
+    console.error("Failed to apply toolbar icon preference", error);
+  }
+}
 
 const IGNORED_NAME_PATTERNS = [
   /working on your task/gi,
@@ -120,6 +196,30 @@ console.log("codex-autorun background service worker loaded.");
 runtime.onInstalled.addListener(() => {
   console.log("codex-autorun installed and ready.");
 });
+
+initializeToolbarIconVisibility();
+
+if (storage?.onChanged?.addListener) {
+  storage.onChanged.addListener((changes, areaName) => {
+    try {
+      const area = areaName ?? (changes?.areaName ?? "local");
+      if (area !== "local") {
+        return;
+      }
+      const change = changes?.[SETTINGS_KEY];
+      if (!change) {
+        return;
+      }
+      const value =
+        Object.prototype.hasOwnProperty.call(change, "newValue")
+          ? change.newValue
+          : change;
+      updateToolbarIconVisibility(isToolbarIconVisible(value));
+    } catch (error) {
+      console.error("Failed to react to toolbar icon preference change", error);
+    }
+  });
+}
 
 function storageGet(key) {
   if (!storage?.local) {

--- a/src/options.html
+++ b/src/options.html
@@ -28,6 +28,23 @@
           your task history.
         </p>
       </section>
+      <section class="options__section" aria-labelledby="toolbar-settings-heading">
+        <div class="section-heading">
+          <h2 id="toolbar-settings-heading">Toolbar</h2>
+          <p class="section-description">
+            Decide whether the codex-autorun icon is visible in your browser's
+            menu bar.
+          </p>
+        </div>
+        <label class="toggle">
+          <input type="checkbox" id="toolbar-icon-visible" checked />
+          <span class="toggle__label">Show icon in menu bar</span>
+        </label>
+        <p class="hint">
+          When hidden, you can still access codex-autorun from your browser's
+          extensions menu.
+        </p>
+      </section>
       <output
         id="options-status"
         class="options__status"

--- a/src/options.js
+++ b/src/options.js
@@ -4,9 +4,11 @@ import {
   getSettings,
   normalizeSettings,
   setSoundNotificationsEnabled,
+  setToolbarIconVisibility,
 } from "./settings.js";
 
 const soundToggle = document.getElementById("sound-enabled");
+const toolbarIconToggle = document.getElementById("toolbar-icon-visible");
 const statusOutput = document.getElementById("options-status");
 
 let isInitializing = true;
@@ -41,6 +43,9 @@ function updateForm(settings) {
   if (soundToggle) {
     soundToggle.checked = normalized.soundNotifications.enabled !== false;
   }
+  if (toolbarIconToggle) {
+    toolbarIconToggle.checked = normalized.toolbarIcon.visible !== false;
+  }
 }
 
 async function loadSettingsIntoForm() {
@@ -72,7 +77,24 @@ async function handleSoundToggleChange() {
   }
 }
 
+async function handleToolbarIconToggleChange() {
+  if (isInitializing || !toolbarIconToggle) {
+    return;
+  }
+  const visible = toolbarIconToggle.checked;
+  setStatus("Saving preferences…");
+  try {
+    await setToolbarIconVisibility(visible);
+    setStatus("Preferences saved.");
+  } catch (error) {
+    console.error("Failed to save toolbar icon setting", error);
+    setStatus(`Unable to save changes: ${error.message}`, { isError: true });
+    toolbarIconToggle.checked = !visible;
+  }
+}
+
 soundToggle?.addEventListener("change", handleSoundToggleChange);
+toolbarIconToggle?.addEventListener("change", handleToolbarIconToggleChange);
 
 document.addEventListener("DOMContentLoaded", () => {
   loadSettingsIntoForm();

--- a/src/settings.js
+++ b/src/settings.js
@@ -4,12 +4,18 @@ export const DEFAULT_SETTINGS = Object.freeze({
   soundNotifications: {
     enabled: true,
   },
+  toolbarIcon: {
+    visible: true,
+  },
 });
 
 function cloneDefaultSettings() {
   return {
     soundNotifications: {
       enabled: DEFAULT_SETTINGS.soundNotifications.enabled,
+    },
+    toolbarIcon: {
+      visible: DEFAULT_SETTINGS.toolbarIcon.visible,
     },
   };
 }
@@ -96,6 +102,16 @@ export function normalizeSettings(rawValue = {}) {
         rawValue.playSoundNotifications,
       );
     }
+
+    const rawToolbar = rawValue.toolbarIcon;
+    if (rawToolbar && typeof rawToolbar === "object") {
+      if (rawToolbar.visible !== undefined) {
+        normalized.toolbarIcon.visible = Boolean(rawToolbar.visible);
+      }
+    } else if (rawValue.showToolbarIcon !== undefined) {
+      // Support a potential legacy flag name.
+      normalized.toolbarIcon.visible = Boolean(rawValue.showToolbarIcon);
+    }
   }
 
   return normalized;
@@ -129,6 +145,10 @@ export async function saveSettings(partialSettings) {
       ...current.soundNotifications,
       ...(partialSettings?.soundNotifications || {}),
     },
+    toolbarIcon: {
+      ...current.toolbarIcon,
+      ...(partialSettings?.toolbarIcon || {}),
+    },
   });
   return writeSettings(next);
 }
@@ -137,6 +157,14 @@ export async function setSoundNotificationsEnabled(enabled) {
   return saveSettings({
     soundNotifications: {
       enabled: Boolean(enabled),
+    },
+  });
+}
+
+export async function setToolbarIconVisibility(visible) {
+  return saveSettings({
+    toolbarIcon: {
+      visible: Boolean(visible),
     },
   });
 }

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { DEFAULT_SETTINGS, normalizeSettings } from "../src/settings.js";
+
+test("toolbar icon visibility defaults to enabled", () => {
+  const normalized = normalizeSettings();
+  assert.strictEqual(
+    normalized.toolbarIcon.visible,
+    true,
+    "Toolbar icon should be visible by default",
+  );
+  assert.strictEqual(
+    DEFAULT_SETTINGS.toolbarIcon.visible,
+    true,
+    "Default settings should enable the toolbar icon",
+  );
+});
+
+test("toolbar icon visibility respects stored preference", () => {
+  const normalized = normalizeSettings({
+    toolbarIcon: { visible: false },
+  });
+  assert.strictEqual(
+    normalized.toolbarIcon.visible,
+    false,
+    "Toolbar icon preference should honor stored visibility",
+  );
+});
+
+test("toolbar icon legacy flat flag is supported", () => {
+  const normalized = normalizeSettings({ showToolbarIcon: false });
+  assert.strictEqual(
+    normalized.toolbarIcon.visible,
+    false,
+    "Legacy toolbar visibility flag should be respected",
+  );
+});


### PR DESCRIPTION
## Summary
- add an options toggle for showing the codex-autorun icon in the browser menu bar
- persist the toolbar icon preference and apply it in the background script
- cover the new settings normalization with automated tests

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68da375725948333aa687089b44f5beb