### PR TITLE
Include pr-created in popup completion statuses

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -14,7 +14,7 @@ const countBadge = document.getElementById("history-count");
 const autoCreatePrTasks = new Set();
 let autoCreatePrQueue = Promise.resolve();
 const lastKnownTaskStatuses = new Map();
-const COMPLETED_STATUS_KEYS = new Set(["ready", "merged"]);
+const COMPLETED_STATUS_KEYS = new Set(["ready", "merged", "pr-created"]);
 
 let hasRenderedHistory = false;
 let audioContext;


### PR DESCRIPTION
## Summary
- add the `pr-created` status to the popup's completion set so it matches the background script

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da48a2232c83339e28258141578941