### PR TITLE
Add optional all-sites permission toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.15 - 2025-09-28
+- Added an optional setting that requests access to all websites so codex-autorun can monitor Codex tasks beyond the default domains.
+
 # 1.1.14 - 2025-09-28
 - Restore the SVG toolbar icons in the manifest so the codex-autorun button reappears in the menu bar.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",
@@ -9,6 +9,7 @@
     "https://chatgpt.com/*",
     "https://debuggpt.tools/*"
   ],
+  "optional_permissions": ["<all_urls>"],
   "icons": {
     "16": "src/icons/icon-16.png",
     "19": "src/icons/icon-19.png",

--- a/src/options.html
+++ b/src/options.html
@@ -45,6 +45,26 @@
           extensions menu.
         </p>
       </section>
+      <section
+        class="options__section"
+        aria-labelledby="permission-settings-heading"
+      >
+        <div class="section-heading">
+          <h2 id="permission-settings-heading">Website access</h2>
+          <p class="section-description">
+            Control whether codex-autorun can monitor Codex tasks on every
+            website you visit.
+          </p>
+        </div>
+        <label class="toggle">
+          <input type="checkbox" id="allow-all-hosts" />
+          <span class="toggle__label">Allow access to all sites</span>
+        </label>
+        <p class="hint">
+          Enable this option if Codex tasks appear on additional domains and you
+          want codex-autorun to watch them automatically.
+        </p>
+      </section>
       <output
         id="options-status"
         class="options__status"

--- a/src/options.js
+++ b/src/options.js
@@ -5,14 +5,36 @@ import {
   normalizeSettings,
   setSoundNotificationsEnabled,
   setToolbarIconVisibility,
+  setAllHostsPermissionPreference,
 } from "./settings.js";
 
 const soundToggle = document.getElementById("sound-enabled");
 const toolbarIconToggle = document.getElementById("toolbar-icon-visible");
+const allowAllHostsToggle = document.getElementById("allow-all-hosts");
 const statusOutput = document.getElementById("options-status");
 
 let isInitializing = true;
 let clearStatusTimeout = null;
+
+const permissionsApi =
+  (typeof browser !== "undefined" && browser?.permissions) ||
+  (typeof chrome !== "undefined" && chrome?.permissions) ||
+  null;
+const usesPromisePermissionsApi =
+  permissionsApi &&
+  typeof browser !== "undefined" &&
+  browser?.permissions === permissionsApi;
+const ALL_HOSTS_PERMISSION = { origins: ["<all_urls>"] };
+
+function getRuntimeLastError() {
+  if (typeof browser !== "undefined" && browser?.runtime?.lastError) {
+    return browser.runtime.lastError;
+  }
+  if (typeof chrome !== "undefined" && chrome?.runtime?.lastError) {
+    return chrome.runtime.lastError;
+  }
+  return null;
+}
 
 function setStatus(message, { isError = false } = {}) {
   if (!statusOutput) {
@@ -46,12 +68,18 @@ function updateForm(settings) {
   if (toolbarIconToggle) {
     toolbarIconToggle.checked = normalized.toolbarIcon.visible !== false;
   }
+  if (allowAllHostsToggle) {
+    allowAllHostsToggle.checked = Boolean(
+      normalized.hostPermissions?.allowAllHosts,
+    );
+  }
 }
 
 async function loadSettingsIntoForm() {
   try {
     const settings = await getSettings();
     updateForm(settings);
+    await syncAllHostsPermission(settings);
   } catch (error) {
     console.error("Failed to load settings", error);
     updateForm(DEFAULT_SETTINGS);
@@ -93,8 +121,130 @@ async function handleToolbarIconToggleChange() {
   }
 }
 
+function hasPermissionsApi() {
+  return Boolean(permissionsApi);
+}
+
+async function requestAllHostsPermission() {
+  if (!hasPermissionsApi() || !permissionsApi?.request) {
+    throw new Error("Browser does not support runtime permissions.");
+  }
+  if (usesPromisePermissionsApi) {
+    return Boolean(await permissionsApi.request(ALL_HOSTS_PERMISSION));
+  }
+  return new Promise((resolve, reject) => {
+    try {
+      permissionsApi.request(ALL_HOSTS_PERMISSION, (granted) => {
+        const lastError = getRuntimeLastError();
+        if (lastError) {
+          reject(new Error(lastError.message || String(lastError)));
+          return;
+        }
+        resolve(Boolean(granted));
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function removeAllHostsPermission() {
+  if (!hasPermissionsApi() || !permissionsApi?.remove) {
+    throw new Error("Browser does not support revoking permissions.");
+  }
+  if (usesPromisePermissionsApi) {
+    return Boolean(await permissionsApi.remove(ALL_HOSTS_PERMISSION));
+  }
+  return new Promise((resolve, reject) => {
+    try {
+      permissionsApi.remove(ALL_HOSTS_PERMISSION, (removed) => {
+        const lastError = getRuntimeLastError();
+        if (lastError) {
+          reject(new Error(lastError.message || String(lastError)));
+          return;
+        }
+        resolve(Boolean(removed));
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function hasAllHostsPermission() {
+  if (!hasPermissionsApi() || !permissionsApi?.contains) {
+    return false;
+  }
+  if (usesPromisePermissionsApi) {
+    return Boolean(await permissionsApi.contains(ALL_HOSTS_PERMISSION));
+  }
+  return new Promise((resolve, reject) => {
+    try {
+      permissionsApi.contains(ALL_HOSTS_PERMISSION, (result) => {
+        const lastError = getRuntimeLastError();
+        if (lastError) {
+          reject(new Error(lastError.message || String(lastError)));
+          return;
+        }
+        resolve(Boolean(result));
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function syncAllHostsPermission(settings) {
+  if (!allowAllHostsToggle) {
+    return;
+  }
+  try {
+    const hasPermission = await hasAllHostsPermission();
+    allowAllHostsToggle.checked = hasPermission;
+    const normalized = normalizeSettings(settings ?? DEFAULT_SETTINGS);
+    if (normalized.hostPermissions?.allowAllHosts !== hasPermission) {
+      await setAllHostsPermissionPreference(hasPermission);
+    }
+  } catch (error) {
+    console.error("Failed to synchronize host permissions", error);
+  }
+}
+
+async function handleAllowAllHostsToggleChange() {
+  if (isInitializing || !allowAllHostsToggle) {
+    return;
+  }
+  const enableAllHosts = allowAllHostsToggle.checked;
+  setStatus("Updating permissions…");
+  try {
+    if (enableAllHosts) {
+      const granted = await requestAllHostsPermission();
+      const hasPermission = granted || (await hasAllHostsPermission());
+      if (!hasPermission) {
+        throw new Error("Permission request was dismissed.");
+      }
+      await setAllHostsPermissionPreference(true);
+    } else {
+      await removeAllHostsPermission();
+      const stillGranted = await hasAllHostsPermission();
+      if (stillGranted) {
+        throw new Error("Permission could not be removed.");
+      }
+      await setAllHostsPermissionPreference(false);
+    }
+    setStatus("Preferences saved.");
+  } catch (error) {
+    console.error("Failed to update all-host permission", error);
+    setStatus(`Unable to update permissions: ${error.message}`, {
+      isError: true,
+    });
+    allowAllHostsToggle.checked = !enableAllHosts;
+  }
+}
+
 soundToggle?.addEventListener("change", handleSoundToggleChange);
 toolbarIconToggle?.addEventListener("change", handleToolbarIconToggleChange);
+allowAllHostsToggle?.addEventListener("change", handleAllowAllHostsToggleChange);
 
 document.addEventListener("DOMContentLoaded", () => {
   loadSettingsIntoForm();
@@ -106,3 +256,31 @@ addSettingsChangeListener((settings) => {
   }
   updateForm(settings);
 });
+
+if (permissionsApi?.onAdded && typeof permissionsApi.onAdded.addListener === "function") {
+  permissionsApi.onAdded.addListener((permissions) => {
+    if (!permissions || !Array.isArray(permissions.origins)) {
+      return;
+    }
+    if (permissions.origins.includes("<all_urls>") && allowAllHostsToggle) {
+      allowAllHostsToggle.checked = true;
+      setAllHostsPermissionPreference(true).catch((error) => {
+        console.error("Failed to persist all-host permission state", error);
+      });
+    }
+  });
+}
+
+if (permissionsApi?.onRemoved && typeof permissionsApi.onRemoved.addListener === "function") {
+  permissionsApi.onRemoved.addListener((permissions) => {
+    if (!permissions || !Array.isArray(permissions.origins)) {
+      return;
+    }
+    if (permissions.origins.includes("<all_urls>") && allowAllHostsToggle) {
+      allowAllHostsToggle.checked = false;
+      setAllHostsPermissionPreference(false).catch((error) => {
+        console.error("Failed to persist all-host permission removal", error);
+      });
+    }
+  });
+}

--- a/src/settings.js
+++ b/src/settings.js
@@ -7,6 +7,9 @@ export const DEFAULT_SETTINGS = Object.freeze({
   toolbarIcon: {
     visible: true,
   },
+  hostPermissions: {
+    allowAllHosts: false,
+  },
 });
 
 function cloneDefaultSettings() {
@@ -16,6 +19,9 @@ function cloneDefaultSettings() {
     },
     toolbarIcon: {
       visible: DEFAULT_SETTINGS.toolbarIcon.visible,
+    },
+    hostPermissions: {
+      allowAllHosts: DEFAULT_SETTINGS.hostPermissions.allowAllHosts,
     },
   };
 }
@@ -112,6 +118,15 @@ export function normalizeSettings(rawValue = {}) {
       // Support a potential legacy flag name.
       normalized.toolbarIcon.visible = Boolean(rawValue.showToolbarIcon);
     }
+
+    const rawHostPermissions = rawValue.hostPermissions;
+    if (rawHostPermissions && typeof rawHostPermissions === "object") {
+      if (rawHostPermissions.allowAllHosts !== undefined) {
+        normalized.hostPermissions.allowAllHosts = Boolean(
+          rawHostPermissions.allowAllHosts,
+        );
+      }
+    }
   }
 
   return normalized;
@@ -149,6 +164,10 @@ export async function saveSettings(partialSettings) {
       ...current.toolbarIcon,
       ...(partialSettings?.toolbarIcon || {}),
     },
+    hostPermissions: {
+      ...current.hostPermissions,
+      ...(partialSettings?.hostPermissions || {}),
+    },
   });
   return writeSettings(next);
 }
@@ -165,6 +184,14 @@ export async function setToolbarIconVisibility(visible) {
   return saveSettings({
     toolbarIcon: {
       visible: Boolean(visible),
+    },
+  });
+}
+
+export async function setAllHostsPermissionPreference(allowAllHosts) {
+  return saveSettings({
+    hostPermissions: {
+      allowAllHosts: Boolean(allowAllHosts),
     },
   });
 }


### PR DESCRIPTION
## Summary
- add an options page toggle that can request or revoke the all-sites host permission and keeps the stored preference in sync
- persist the host permission preference in extension settings and react to runtime permission changes
- declare the optional <all_urls> permission in the manifest and bump the changelog/version

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da4df8b1148333a46b990f01b1791c