### PR TITLE
Move settings controls into popup header

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -24,6 +24,15 @@ main {
   gap: 0.75rem;
 }
 
+.banner-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.banner-actions > button {
+  white-space: nowrap;
+}
+
 .banner h1 {
   font-size: 1.125rem;
   margin: 0;
@@ -105,55 +114,6 @@ button:disabled {
   gap: 0.75rem;
   max-height: 320px;
   overflow-y: auto;
-}
-
-.settings {
-  background: #ffffff;
-  border-radius: 0.75rem;
-  border: 1px solid #e2e8f0;
-  padding: 0.75rem;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.settings-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.settings-heading h2 {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.settings-open {
-  padding: 0.35rem 0.65rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-
-.settings-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
-  cursor: pointer;
-}
-
-.settings-toggle input[type="checkbox"] {
-  width: 1.1rem;
-  height: 1.1rem;
-  cursor: pointer;
-}
-
-.settings-note {
-  margin: 0;
-  color: #64748b;
-  font-size: 0.8rem;
 }
 
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -9,7 +9,12 @@
     <main>
       <header class="banner">
         <h1>codex-autorun</h1>
-        <button id="refresh" type="button" title="Refresh history">Refresh</button>
+        <div class="banner-actions">
+          <button id="refresh" type="button" title="Refresh history">Refresh</button>
+          <button id="open-settings" type="button" title="Open extension settings">
+            Settings
+          </button>
+        </div>
       </header>
       <p class="description">
         Monitoring for Codex tasks that show the working indicator square.
@@ -21,21 +26,6 @@
         </div>
         <p id="empty-state" class="empty">No tasks detected yet.</p>
         <ol id="history" class="history-list"></ol>
-      </section>
-      <section class="settings" aria-labelledby="settings-title">
-        <div class="settings-heading">
-          <h2 id="settings-title">Settings</h2>
-          <button id="open-settings" type="button" class="settings-open">
-            Open full settings
-          </button>
-        </div>
-        <label class="settings-toggle">
-          <input type="checkbox" id="toolbar-icon-toggle" />
-          <span>Show icon in the browser menu bar</span>
-        </label>
-        <p class="settings-note">
-          Hiding the icon moves controls to the extension's settings page.
-        </p>
       </section>
       <output id="error" role="status" aria-live="polite"></output>
     </main>

--- a/src/popup.js
+++ b/src/popup.js
@@ -2,19 +2,11 @@ const runtime =
   typeof browser !== "undefined" && browser?.runtime
     ? browser.runtime
     : chrome?.runtime;
-const storage =
-  typeof browser !== "undefined" && browser?.storage
-    ? browser.storage
-    : chrome?.storage;
-
-const SHOW_BROWSER_ACTION_ICON_KEY = "codexShowBrowserActionIcon";
-
 const refreshButton = document.getElementById("refresh");
 const historyList = document.getElementById("history");
 const emptyState = document.getElementById("empty-state");
 const errorOutput = document.getElementById("error");
 const countBadge = document.getElementById("history-count");
-const toolbarIconToggle = document.getElementById("toolbar-icon-toggle");
 const openSettingsButton = document.getElementById("open-settings");
 
 const autoCreatePrTasks = new Set();
@@ -111,54 +103,6 @@ function sendMessage(message) {
     });
   }
   return Promise.reject(new Error("Runtime messaging is unavailable."));
-}
-
-function storageGetValue(key) {
-  if (!storage?.local) {
-    return Promise.resolve(undefined);
-  }
-  try {
-    const result = storage.local.get(key);
-    if (result && typeof result.then === "function") {
-      return result.then((data) => data?.[key]);
-    }
-  } catch (error) {
-    console.error("Failed to get popup storage value", error);
-  }
-  return new Promise((resolve) => {
-    storage.local.get(key, (data) => {
-      if (runtime?.lastError) {
-        console.error("Popup storage get error", runtime.lastError);
-        resolve(undefined);
-        return;
-      }
-      resolve(data?.[key]);
-    });
-  });
-}
-
-function storageSetValue(key, value) {
-  if (!storage?.local) {
-    return Promise.resolve();
-  }
-  const payload = { [key]: value };
-  try {
-    const result = storage.local.set(payload);
-    if (result && typeof result.then === "function") {
-      return result;
-    }
-  } catch (error) {
-    console.error("Failed to update popup storage value", error);
-  }
-  return new Promise((resolve, reject) => {
-    storage.local.set(payload, () => {
-      if (runtime?.lastError) {
-        reject(new Error(runtime.lastError.message));
-        return;
-      }
-      resolve();
-    });
-  });
 }
 
 function openOptionsPage() {
@@ -543,41 +487,6 @@ async function loadHistory() {
   }
 }
 
-async function initializeToolbarIconToggle() {
-  if (!toolbarIconToggle) {
-    return;
-  }
-
-  toolbarIconToggle.disabled = true;
-  try {
-    const stored = await storageGetValue(SHOW_BROWSER_ACTION_ICON_KEY);
-    toolbarIconToggle.checked = stored !== false;
-  } catch (error) {
-    console.error("Failed to load toolbar visibility setting", error);
-    if (errorOutput) {
-      errorOutput.textContent = `Unable to load settings: ${error.message}`;
-    }
-  } finally {
-    toolbarIconToggle.disabled = false;
-  }
-
-  toolbarIconToggle.addEventListener("change", async () => {
-    const desiredState = toolbarIconToggle.checked;
-    toolbarIconToggle.disabled = true;
-    try {
-      await storageSetValue(SHOW_BROWSER_ACTION_ICON_KEY, desiredState);
-    } catch (error) {
-      console.error("Failed to update toolbar visibility setting", error);
-      if (errorOutput) {
-        errorOutput.textContent = `Unable to update setting: ${error.message}`;
-      }
-      toolbarIconToggle.checked = !desiredState;
-    } finally {
-      toolbarIconToggle.disabled = false;
-    }
-  });
-}
-
 function handleOpenSettingsClick(event) {
   event?.preventDefault();
   if (!openSettingsButton) {
@@ -607,5 +516,4 @@ openSettingsButton?.addEventListener("click", handleOpenSettingsClick);
 
 window.addEventListener("DOMContentLoaded", () => {
   loadHistory();
-  initializeToolbarIconToggle();
 });


### PR DESCRIPTION
## Summary
- move the Settings action into the popup header beside Refresh
- remove the now-unused settings panel markup, styling, and toggle logic
- streamline popup script by dropping storage helpers that only supported the toggle

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68da710dc5b883338409d82de9b77e61