### PR TITLE
Rename toolbar toggle to "Pin to Toolbar"

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -17,7 +17,7 @@
         </div>
         <label class="toggle">
           <input type="checkbox" id="toolbar-icon-toggle" />
-          <span>Show the codex-autorun icon in the browser menu bar</span>
+          <span>Pin to Toolbar</span>
         </label>
         <p class="hint">
           If you hide the toolbar icon, you can return here to show it again.


### PR DESCRIPTION
## Summary
- update the toolbar visibility toggle label in the options page to read "Pin to Toolbar"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da7585829c83339a6f30477f301853