### PR TITLE
Ensure toolbar icon unpins when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.14 - 2025-09-28
+- Allow the toolbar icon to unpin immediately when the options toggle is unchecked.
+
 # 1.1.13 - 2025-09-28
 - Removed the smart check action from the popup and background services.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/background.js
+++ b/src/background.js
@@ -725,6 +725,18 @@ runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
+  if (message.type === "set-toolbar-visibility") {
+    const shouldShow = message?.shouldShow !== false;
+    setBrowserActionVisibility(shouldShow).then(
+      () => sendResponse?.({ type: "ack" }),
+      (error) => {
+        console.error("Failed to set toolbar visibility", error);
+        sendResponse?.({ type: "error", message: String(error) });
+      },
+    );
+    return true;
+  }
+
   return false;
 });
 


### PR DESCRIPTION
## Summary
- send a runtime message from the options page so the toolbar pin preference applies immediately
- add a background message handler to hide or show the browser action on demand
- bump the extension version and document the change

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da7c8efc0883339775f6fc17306833