### PR TITLE
Document linting workflow for codex-autorun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.16 - 2025-09-28
+- Documented how to lint the extension with `web-ext` so contributors can quickly sanity-check changes.
+
 # 1.1.15 - 2025-09-28
 - Added notification sound preferences to the settings page so you can choose which task statuses play audio alerts.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ When a tracked task leaves the "working" state, the popup now highlights it as *
 
 The extension remains installed until you restart Firefox. Repeat the steps above to load it again after restarting the browser.
 
+## Testing
+
+This project does not include automated tests. You can still verify the extension setup by running `web-ext lint` from the
+repository root. The command requires the [`web-ext`](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/)
+CLI, which is available through npm:
+
+```bash
+npm install --global web-ext
+web-ext lint
+```
+
+Linting helps catch manifest or script issues before manually loading the extension in Firefox.
+
 ## Project update rules
 
 To keep the project history consistent:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary
- document how to use web-ext lint to sanity check the extension
- bump the extension version to 1.1.16 and record the change in the changelog

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68da86a5a754833391a963a131b1dda6