### PR TITLE
Add configurable notification sounds per status

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,5 +43,6 @@
       "js": ["src/codexWatcher.js"],
       "run_at": "document_idle"
     }
-  ]
+  ],
+  "web_accessible_resources": ["src/sounds/*.mp3"]
 }

--- a/src/options.css
+++ b/src/options.css
@@ -64,6 +64,35 @@ main {
   font-size: 0.95rem;
 }
 
+.sound-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.sound-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.sound-select select {
+  min-width: 8rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  color: inherit;
+}
+
+.sound-select select:disabled {
+  opacity: 0.5;
+}
+
 .checkbox-option input[type="checkbox"] {
   width: 1.1rem;
   height: 1.1rem;

--- a/src/options.html
+++ b/src/options.html
@@ -34,18 +34,63 @@
               Play a notification sound when a task becomes:
             </legend>
             <div class="checkbox-list">
-              <label class="checkbox-option">
-                <input type="checkbox" name="sound-status" value="ready" />
-                Ready
-              </label>
-              <label class="checkbox-option">
-                <input type="checkbox" name="sound-status" value="pr-created" />
-                PR created
-              </label>
-              <label class="checkbox-option">
-                <input type="checkbox" name="sound-status" value="merged" />
-                Merged
-              </label>
+              <div class="sound-option">
+                <label class="checkbox-option">
+                  <input type="checkbox" name="sound-status" value="ready" />
+                  Ready
+                </label>
+                <label class="sound-select">
+                  <span class="sound-select-label">Sound</span>
+                  <select name="sound-selection" data-status="ready">
+                    <option value="1.mp3">Sound 1</option>
+                    <option value="2.mp3">Sound 2</option>
+                    <option value="3.mp3">Sound 3</option>
+                    <option value="4.mp3">Sound 4</option>
+                    <option value="5.mp3">Sound 5</option>
+                    <option value="6.mp3">Sound 6</option>
+                    <option value="7.mp3">Sound 7</option>
+                    <option value="8.mp3">Sound 8</option>
+                  </select>
+                </label>
+              </div>
+              <div class="sound-option">
+                <label class="checkbox-option">
+                  <input type="checkbox" name="sound-status" value="pr-created" />
+                  PR created
+                </label>
+                <label class="sound-select">
+                  <span class="sound-select-label">Sound</span>
+                  <select name="sound-selection" data-status="pr-created">
+                    <option value="1.mp3">Sound 1</option>
+                    <option value="2.mp3">Sound 2</option>
+                    <option value="3.mp3">Sound 3</option>
+                    <option value="4.mp3">Sound 4</option>
+                    <option value="5.mp3">Sound 5</option>
+                    <option value="6.mp3">Sound 6</option>
+                    <option value="7.mp3">Sound 7</option>
+                    <option value="8.mp3">Sound 8</option>
+                  </select>
+                </label>
+              </div>
+              <div class="sound-option">
+                <label class="checkbox-option">
+                  <input type="checkbox" name="sound-status" value="merged" />
+                  Merged
+                </label>
+                <label class="sound-select">
+                  <span class="sound-select-label">Sound</span>
+                  <select name="sound-selection" data-status="merged">
+                    <option value="1.mp3">Sound 1</option>
+                    <option value="2.mp3">Sound 2</option>
+                    <option value="3.mp3">Sound 3</option>
+                    <option value="4.mp3">Sound 4</option>
+                    <option value="5.mp3">Sound 5</option>
+                    <option value="6.mp3">Sound 6</option>
+                    <option value="7.mp3">Sound 7</option>
+                    <option value="8.mp3">Sound 8</option>
+                  </select>
+                </label>
+              </div>
             </div>
           </fieldset>
         </form>


### PR DESCRIPTION
## Summary
- add dropdown selectors on the options page to choose a sound file for each task status
- persist sound selections alongside enabled statuses and expose bundled mp3 assets to the popup
- update popup playback logic to load the selected mp3 for each status change while keeping existing action tones

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da87f7d53c8333b21eaa3cb17602c2