### PR TITLE
Add configurable browser notifications for Codex task updates

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "permissions": [
     "storage",
     "tabs",
+    "notifications",
     "https://chatgpt.com/*",
     "https://debuggpt.tools/*"
   ],

--- a/src/options.css
+++ b/src/options.css
@@ -105,10 +105,12 @@ main {
   color: #64748b;
 }
 
-#sound-status-message {
+#sound-status-message,
+#notification-status-message {
   min-height: 1.25rem;
 }
 
-#sound-status-message.error {
+#sound-status-message.error,
+#notification-status-message.error {
   color: #b91c1c;
 }

--- a/src/options.html
+++ b/src/options.html
@@ -96,6 +96,42 @@
         </form>
         <p class="hint" id="sound-status-message" role="status" aria-live="polite"></p>
       </section>
+
+      <section class="card" aria-labelledby="browser-notifications-title">
+        <div class="card-header">
+          <h2 id="browser-notifications-title">Browser notifications</h2>
+        </div>
+        <p class="hint">
+          Choose which task status changes should trigger a browser notification.
+        </p>
+        <form id="notification-preferences">
+          <fieldset>
+            <legend class="fieldset-title">
+              Show a notification when a task becomes:
+            </legend>
+            <div class="checkbox-list">
+              <label class="checkbox-option">
+                <input type="checkbox" name="notification-status" value="ready" />
+                Ready
+              </label>
+              <label class="checkbox-option">
+                <input type="checkbox" name="notification-status" value="pr-created" />
+                PR created
+              </label>
+              <label class="checkbox-option">
+                <input type="checkbox" name="notification-status" value="merged" />
+                Merged
+              </label>
+            </div>
+          </fieldset>
+        </form>
+        <p
+          class="hint"
+          id="notification-status-message"
+          role="status"
+          aria-live="polite"
+        ></p>
+      </section>
     </main>
     <script src="options.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- enable WebExtension notifications and surface status changes via browser notifications in the background script
- make notification targets configurable through new options UI backed by synced storage
- update options styling to cover the new notification status message area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8ace32888333a6b5291067ea9031