### PR TITLE
Rename Ready status label to Task ready to view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.1.16 - 2025-09-28
+- Renamed the Ready status label across the extension to **Task ready to view** so notifications and settings reflect the new wording.
+
 # 1.1.15 - 2025-09-28
 - Added notification sound preferences to the settings page so you can choose which task statuses play audio alerts.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the codex-autorun Firefox-compatible WebExtension with 
 
 ## Popup workflow
 
-When a tracked task leaves the "working" state, the popup now highlights it as **Ready** and provides a **Create PR** action. Clicking the button opens the original task link in a new tab and marks the stored status as **PR created** so you can track which tasks already have pull requests in flight. All other tasks expose an **Open task** action for quick access to their Codex links.
+When a tracked task leaves the "working" state, the popup now highlights it as **Task ready to view** and provides a **Create PR** action. Clicking the button opens the original task link in a new tab and marks the stored status as **PR created** so you can track which tasks already have pull requests in flight. All other tasks expose an **Open task** action for quick access to their Codex links.
 
 ## Load the extension in Firefox
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/background.js
+++ b/src/background.js
@@ -32,7 +32,7 @@ const IGNORED_NAME_PATTERNS = [
   /committing changes?/gi,
 ];
 const STATUS_LABELS = {
-  ready: "Ready",
+  ready: "Task ready to view",
   "pr-created": "PR created",
   merged: "Merged",
 };

--- a/src/options.html
+++ b/src/options.html
@@ -37,7 +37,7 @@
               <div class="sound-option">
                 <label class="checkbox-option">
                   <input type="checkbox" name="sound-status" value="ready" />
-                  Ready
+                  Task ready to view
                 </label>
                 <label class="sound-select">
                   <span class="sound-select-label">Sound</span>
@@ -112,7 +112,7 @@
             <div class="checkbox-list">
               <label class="checkbox-option">
                 <input type="checkbox" name="notification-status" value="ready" />
-                Ready
+                Task ready to view
               </label>
               <label class="checkbox-option">
                 <input type="checkbox" name="notification-status" value="pr-created" />


### PR DESCRIPTION
## Summary
- rename the Ready status label to Task ready to view so background notifications and settings use the updated wording
- document the wording change and bump the extension version to 1.1.16

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da902dd10c8333863fa10c45013395