### PR TITLE
Add custom sound selections for browser notifications

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -110,18 +110,66 @@
               Show a notification when a task becomes:
             </legend>
             <div class="checkbox-list">
-              <label class="checkbox-option">
-                <input type="checkbox" name="notification-status" value="ready" />
-                Task ready to view
-              </label>
-              <label class="checkbox-option">
-                <input type="checkbox" name="notification-status" value="pr-created" />
-                PR created
-              </label>
-              <label class="checkbox-option">
-                <input type="checkbox" name="notification-status" value="merged" />
-                Merged
-              </label>
+              <div class="sound-option">
+                <label class="checkbox-option">
+                  <input type="checkbox" name="notification-status" value="ready" />
+                  Task ready to view
+                </label>
+                <label class="sound-select">
+                  <span class="sound-select-label">Sound</span>
+                  <select name="notification-sound-selection" data-status="ready">
+                    <option value="1.mp3">Sound 1</option>
+                    <option value="2.mp3">Sound 2</option>
+                    <option value="3.mp3">Sound 3</option>
+                    <option value="4.mp3">Sound 4</option>
+                    <option value="5.mp3">Sound 5</option>
+                    <option value="6.mp3">Sound 6</option>
+                    <option value="7.mp3">Sound 7</option>
+                    <option value="8.mp3">Sound 8</option>
+                  </select>
+                </label>
+              </div>
+              <div class="sound-option">
+                <label class="checkbox-option">
+                  <input type="checkbox" name="notification-status" value="pr-created" />
+                  PR created
+                </label>
+                <label class="sound-select">
+                  <span class="sound-select-label">Sound</span>
+                  <select
+                    name="notification-sound-selection"
+                    data-status="pr-created"
+                  >
+                    <option value="1.mp3">Sound 1</option>
+                    <option value="2.mp3">Sound 2</option>
+                    <option value="3.mp3">Sound 3</option>
+                    <option value="4.mp3">Sound 4</option>
+                    <option value="5.mp3">Sound 5</option>
+                    <option value="6.mp3">Sound 6</option>
+                    <option value="7.mp3">Sound 7</option>
+                    <option value="8.mp3">Sound 8</option>
+                  </select>
+                </label>
+              </div>
+              <div class="sound-option">
+                <label class="checkbox-option">
+                  <input type="checkbox" name="notification-status" value="merged" />
+                  Merged
+                </label>
+                <label class="sound-select">
+                  <span class="sound-select-label">Sound</span>
+                  <select name="notification-sound-selection" data-status="merged">
+                    <option value="1.mp3">Sound 1</option>
+                    <option value="2.mp3">Sound 2</option>
+                    <option value="3.mp3">Sound 3</option>
+                    <option value="4.mp3">Sound 4</option>
+                    <option value="5.mp3">Sound 5</option>
+                    <option value="6.mp3">Sound 6</option>
+                    <option value="7.mp3">Sound 7</option>
+                    <option value="8.mp3">Sound 8</option>
+                  </select>
+                </label>
+              </div>
             </div>
           </fieldset>
         </form>


### PR DESCRIPTION
## Summary
- add per-status sound dropdowns to the browser notifications settings card
- persist notification sound selections and disable dropdowns when a status is turned off
- play the chosen bundled sound file from the background script when a browser notification fires

## Testing
- not run (extension changes)


------
https://chatgpt.com/codex/tasks/task_e_68da9ddd83c48333bf3b5d0c427de15d