### PR TITLE
Remove toolbar visibility section from options page

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -11,16 +11,6 @@
         <h1>codex-autorun settings</h1>
         <p>Adjust extension preferences.</p>
       </header>
-      <section class="card" aria-labelledby="toolbar-title">
-        <div class="card-header">
-          <h2 id="toolbar-title">Toolbar visibility</h2>
-        </div>
-        <p class="hint">
-          Use your browser's extension menu to pin or unpin codex-autorun from the
-          toolbar.
-        </p>
-      </section>
-
       <section class="card" aria-labelledby="notifications-title">
         <div class="card-header">
           <h2 id="notifications-title">Notification sounds</h2>


### PR DESCRIPTION
## Summary
- remove the unused "Toolbar visibility" card from the options page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac4e55f408333b3371fe11ede5241