### PR TITLE
Silence Chrome notification chime

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -270,6 +270,7 @@ async function showStatusNotification(task, statusKey) {
   try {
     const notificationId = await createNotification({
       type: "basic",
+      silent: true,
       iconUrl,
       title: `${statusLabel} task`,
       message,


### PR DESCRIPTION
## Summary
- add the `silent` flag to extension notifications so Chrome does not play its default alert sound

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dac8ce19e88333a2cdd834b6ab1408