### PR TITLE
Fix Create PR auto-click within iframe contexts

### DIFF
--- a/src/codexWatcher.js
+++ b/src/codexWatcher.js
@@ -1050,6 +1050,14 @@ function findCreatePrButtonInRoot(root) {
   return null;
 }
 
+function getFrameDocument(frame) {
+  try {
+    return frame?.contentDocument || frame?.contentWindow?.document || null;
+  } catch (error) {
+    return null;
+  }
+}
+
 function findCreatePrButton() {
   const visitedRoots = new Set();
 
@@ -1076,6 +1084,19 @@ function findCreatePrButton() {
           return match;
         }
         queue.push(shadowRoot);
+      }
+
+      const tagName = element?.tagName?.toLowerCase?.();
+      if (tagName === "iframe" || tagName === "frame") {
+        const frameDocument = getFrameDocument(element);
+        if (frameDocument && !visitedRoots.has(frameDocument)) {
+          visitedRoots.add(frameDocument);
+          const match = findCreatePrButtonInRoot(frameDocument);
+          if (match) {
+            return match;
+          }
+          queue.push(frameDocument);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- extend the Create PR button search to traverse same-origin iframes
- ensure the auto-click routine can locate the button when Codex renders it inside a frame

## Testing
- not run (extension code change)


------
https://chatgpt.com/codex/tasks/task_e_68dad2a5730c8333833d4c1ab895ae3b