### PR TITLE
Add per-status notification sound toggles

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -72,12 +72,34 @@ main {
   flex-wrap: wrap;
 }
 
+.sound-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.sound-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
 .sound-select {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
   color: #475569;
+}
+
+.sound-toggle input[type="checkbox"],
+.checkbox-option input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #2563eb;
 }
 
 .sound-select select {
@@ -89,14 +111,9 @@ main {
   color: inherit;
 }
 
+.sound-toggle input[type="checkbox"]:disabled,
 .sound-select select:disabled {
   opacity: 0.5;
-}
-
-.checkbox-option input[type="checkbox"] {
-  width: 1.1rem;
-  height: 1.1rem;
-  accent-color: #2563eb;
 }
 
 .hint {

--- a/src/options.html
+++ b/src/options.html
@@ -29,60 +29,99 @@
                   <input type="checkbox" name="notification-status" value="ready" />
                   Task ready to view
                 </label>
-                <label class="sound-select">
-                  <span class="sound-select-label">Sound</span>
-                  <select name="notification-sound-selection" data-status="ready">
-                    <option value="1.mp3">Sound 1</option>
-                    <option value="2.mp3">Sound 2</option>
-                    <option value="3.mp3">Sound 3</option>
-                    <option value="4.mp3">Sound 4</option>
-                    <option value="5.mp3">Sound 5</option>
-                    <option value="6.mp3">Sound 6</option>
-                    <option value="7.mp3">Sound 7</option>
-                    <option value="8.mp3">Sound 8</option>
-                  </select>
-                </label>
+                <div class="sound-controls">
+                  <label class="sound-toggle">
+                    <input
+                      type="checkbox"
+                      name="notification-sound-enabled"
+                      data-status="ready"
+                      checked
+                    />
+                    Play sound
+                  </label>
+                  <label class="sound-select">
+                    <span class="sound-select-label">Sound</span>
+                    <select
+                      name="notification-sound-selection"
+                      data-status="ready"
+                    >
+                      <option value="1.mp3">Sound 1</option>
+                      <option value="2.mp3">Sound 2</option>
+                      <option value="3.mp3">Sound 3</option>
+                      <option value="4.mp3">Sound 4</option>
+                      <option value="5.mp3">Sound 5</option>
+                      <option value="6.mp3">Sound 6</option>
+                      <option value="7.mp3">Sound 7</option>
+                      <option value="8.mp3">Sound 8</option>
+                    </select>
+                  </label>
+                </div>
               </div>
               <div class="sound-option">
                 <label class="checkbox-option">
                   <input type="checkbox" name="notification-status" value="pr-created" />
                   PR created
                 </label>
-                <label class="sound-select">
-                  <span class="sound-select-label">Sound</span>
-                  <select
-                    name="notification-sound-selection"
-                    data-status="pr-created"
-                  >
-                    <option value="1.mp3">Sound 1</option>
-                    <option value="2.mp3">Sound 2</option>
-                    <option value="3.mp3">Sound 3</option>
-                    <option value="4.mp3">Sound 4</option>
-                    <option value="5.mp3">Sound 5</option>
-                    <option value="6.mp3">Sound 6</option>
-                    <option value="7.mp3">Sound 7</option>
-                    <option value="8.mp3">Sound 8</option>
-                  </select>
-                </label>
+                <div class="sound-controls">
+                  <label class="sound-toggle">
+                    <input
+                      type="checkbox"
+                      name="notification-sound-enabled"
+                      data-status="pr-created"
+                      checked
+                    />
+                    Play sound
+                  </label>
+                  <label class="sound-select">
+                    <span class="sound-select-label">Sound</span>
+                    <select
+                      name="notification-sound-selection"
+                      data-status="pr-created"
+                    >
+                      <option value="1.mp3">Sound 1</option>
+                      <option value="2.mp3">Sound 2</option>
+                      <option value="3.mp3">Sound 3</option>
+                      <option value="4.mp3">Sound 4</option>
+                      <option value="5.mp3">Sound 5</option>
+                      <option value="6.mp3">Sound 6</option>
+                      <option value="7.mp3">Sound 7</option>
+                      <option value="8.mp3">Sound 8</option>
+                    </select>
+                  </label>
+                </div>
               </div>
               <div class="sound-option">
                 <label class="checkbox-option">
                   <input type="checkbox" name="notification-status" value="merged" />
                   Merged
                 </label>
-                <label class="sound-select">
-                  <span class="sound-select-label">Sound</span>
-                  <select name="notification-sound-selection" data-status="merged">
-                    <option value="1.mp3">Sound 1</option>
-                    <option value="2.mp3">Sound 2</option>
-                    <option value="3.mp3">Sound 3</option>
-                    <option value="4.mp3">Sound 4</option>
-                    <option value="5.mp3">Sound 5</option>
-                    <option value="6.mp3">Sound 6</option>
-                    <option value="7.mp3">Sound 7</option>
-                    <option value="8.mp3">Sound 8</option>
-                  </select>
-                </label>
+                <div class="sound-controls">
+                  <label class="sound-toggle">
+                    <input
+                      type="checkbox"
+                      name="notification-sound-enabled"
+                      data-status="merged"
+                      checked
+                    />
+                    Play sound
+                  </label>
+                  <label class="sound-select">
+                    <span class="sound-select-label">Sound</span>
+                    <select
+                      name="notification-sound-selection"
+                      data-status="merged"
+                    >
+                      <option value="1.mp3">Sound 1</option>
+                      <option value="2.mp3">Sound 2</option>
+                      <option value="3.mp3">Sound 3</option>
+                      <option value="4.mp3">Sound 4</option>
+                      <option value="5.mp3">Sound 5</option>
+                      <option value="6.mp3">Sound 6</option>
+                      <option value="7.mp3">Sound 7</option>
+                      <option value="8.mp3">Sound 8</option>
+                    </select>
+                  </label>
+                </div>
               </div>
             </div>
           </fieldset>


### PR DESCRIPTION
## Summary
- add per-status "Play sound" toggles to the notification preferences UI and style them alongside the sound selector
- persist per-status sound enablement in options.js and disable sound selectors when notifications or sounds are off
- update the background worker to read the new sound enablement setting and skip playback when a status is silent

## Testing
- not run (extension changes)


------
https://chatgpt.com/codex/tasks/task_e_68db82014bfc8333b74aa1e3fe08b99c