### PR TITLE
Remove duplicate sound labels on notification settings

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -40,10 +40,10 @@
                     Play sound
                   </label>
                   <label class="sound-select">
-                    <span class="sound-select-label">Sound</span>
                     <select
                       name="notification-sound-selection"
                       data-status="ready"
+                      aria-label="Sound"
                     >
                       <option value="1.mp3">Sound 1</option>
                       <option value="2.mp3">Sound 2</option>
@@ -73,10 +73,10 @@
                     Play sound
                   </label>
                   <label class="sound-select">
-                    <span class="sound-select-label">Sound</span>
                     <select
                       name="notification-sound-selection"
                       data-status="pr-created"
+                      aria-label="Sound"
                     >
                       <option value="1.mp3">Sound 1</option>
                       <option value="2.mp3">Sound 2</option>
@@ -106,10 +106,10 @@
                     Play sound
                   </label>
                   <label class="sound-select">
-                    <span class="sound-select-label">Sound</span>
                     <select
                       name="notification-sound-selection"
                       data-status="merged"
+                      aria-label="Sound"
                     >
                       <option value="1.mp3">Sound 1</option>
                       <option value="2.mp3">Sound 2</option>


### PR DESCRIPTION
## Summary
- remove the duplicated visible "Sound" text on each notification sound selector
- preserve accessibility by adding an aria-label to each dropdown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db86daf3e08333b08cc905adc44cb2