### PR TITLE
Silence default notification sound

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -307,6 +307,7 @@ async function showStatusNotification(task, statusKey) {
       title: `${statusLabel} task`,
       message,
       contextMessage: task?.url ? `${contextMessage} Click to open.` : contextMessage,
+      silent: true,
     });
 
     if (notificationId && task?.url) {


### PR DESCRIPTION
## Summary
- mark browser notifications as silent so only the custom sound plays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db88ddfc6083338ce8690a74891943