### PR TITLE
Silence default browser notification sound

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -307,6 +307,7 @@ async function showStatusNotification(task, statusKey) {
       title: `${statusLabel} task`,
       message,
       contextMessage: task?.url ? `${contextMessage} Click to open.` : contextMessage,
+      silent: true,
     });
 
     if (notificationId && task?.url) {


### PR DESCRIPTION
## Summary
- add the silent flag to created notifications to suppress the browser's default sound

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db91c044a88333b25051d83a312b87