### PR TITLE
Allow notification sound customization when default muted

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -270,7 +270,6 @@ function updateNotificationSoundToggleState() {
   }
 
   const notificationEnabled = new Set(cachedNotificationStatuses);
-  const defaultSoundMuted = Boolean(cachedDefaultSoundMuted);
   const toggles = form.querySelectorAll(
     'input[name="notification-sound-enabled"]',
   );
@@ -281,7 +280,7 @@ function updateNotificationSoundToggleState() {
       continue;
     }
 
-    toggle.disabled = defaultSoundMuted || !notificationEnabled.has(status);
+    toggle.disabled = !notificationEnabled.has(status);
   }
 }
 
@@ -293,7 +292,6 @@ function updateNotificationSoundSelectState() {
 
   const notificationEnabled = new Set(cachedNotificationStatuses);
   const soundEnabled = new Set(cachedSoundEnabledStatuses);
-  const defaultSoundMuted = Boolean(cachedDefaultSoundMuted);
   const selects = form.querySelectorAll(
     'select[name="notification-sound-selection"]',
   );
@@ -307,7 +305,7 @@ function updateNotificationSoundSelectState() {
     const enabled =
       notificationEnabled.has(status) && soundEnabled.has(status);
 
-    select.disabled = defaultSoundMuted || !enabled;
+    select.disabled = !enabled;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep per-status sound toggles enabled unless their notification is off
- leave sound selection dropdowns active when status notifications and sounds stay enabled
- ensure muted default audio still silences built-in clips while custom overrides continue playing

## Testing
- not run (extension only)


------
https://chatgpt.com/codex/tasks/task_e_68db9a0c838c8333a7116023c1164f7a