### PR TITLE
Fix custom notification sounds when default muted

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -53,7 +53,6 @@ const SOUND_FILE_OPTIONS = [
 const SOUND_FILE_SET = new Set(SOUND_FILE_OPTIONS);
 const STATUS_VALUE_SET = new Set(["ready", "pr-created", "merged"]);
 let notificationEnabledStatuses = new Set(DEFAULT_NOTIFICATION_STATUSES);
-let notificationSoundSelectionOverrides = {};
 let notificationSoundSelections = { ...DEFAULT_NOTIFICATION_SOUND_SELECTIONS };
 let notificationSoundEnabledStatuses = new Set(
   DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES,
@@ -152,21 +151,6 @@ function updateNotificationEnabledStatuses(statuses) {
 }
 
 function updateNotificationSoundSelections(selections) {
-  const overrides = {};
-  if (selections && typeof selections === "object") {
-    for (const status of STATUS_VALUE_SET) {
-      const value = selections?.[status];
-      if (typeof value !== "string") {
-        continue;
-      }
-      if (value === DEFAULT_NOTIFICATION_SOUND_SELECTIONS[status]) {
-        continue;
-      }
-      overrides[status] = value;
-    }
-  }
-
-  notificationSoundSelectionOverrides = overrides;
   notificationSoundSelections = {
     ...DEFAULT_NOTIFICATION_SOUND_SELECTIONS,
     ...(selections ?? {}),
@@ -317,16 +301,6 @@ function playBrowserNotificationSound(statusKey) {
     return;
   }
 
-  if (
-    notificationDefaultSoundMuted &&
-    !Object.prototype.hasOwnProperty.call(
-      notificationSoundSelectionOverrides,
-      statusKey,
-    )
-  ) {
-    return;
-  }
-
   const rawSelection = notificationSoundSelections?.[statusKey];
   const trimmed = typeof rawSelection === "string" ? rawSelection.trim() : "";
   const normalized =
@@ -335,6 +309,13 @@ function playBrowserNotificationSound(statusKey) {
       : DEFAULT_NOTIFICATION_SOUND_SELECTIONS[statusKey];
 
   if (!normalized || !SOUND_FILE_SET.has(normalized)) {
+    return;
+  }
+
+  if (
+    notificationDefaultSoundMuted &&
+    normalized === DEFAULT_NOTIFICATION_SOUND_SELECTIONS[statusKey]
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow custom notification sounds to play even when the default sound is muted by checking the resolved selection before skipping playback
- remove unused override tracking from the background notification sound preferences loader

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9e716e2c8333b96f79ebb6ba7cac