### PR TITLE
Mute default notification chime when muted

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -361,7 +361,10 @@ async function showStatusNotification(task, statusKey) {
       iconUrl,
       title: `${statusLabel} task`,
       message,
-      contextMessage: task?.url ? `${contextMessage} Click to open.` : contextMessage,
+      contextMessage: task?.url
+        ? `${contextMessage} Click to open.`
+        : contextMessage,
+      silent: notificationDefaultSoundMuted || undefined,
     });
 
     if (notificationId && task?.url) {


### PR DESCRIPTION
## Summary
- add the `silent` flag to status notifications when the user mutes the default sound
- ensure only the custom audio plays when the default sound is muted

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbaa9598a083338fdf3ea3b1fdab10