### PR TITLE
Fix custom notification sounds when default audio is muted

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -317,16 +317,6 @@ function playBrowserNotificationSound(statusKey) {
     return;
   }
 
-  if (
-    notificationDefaultSoundMuted &&
-    !Object.prototype.hasOwnProperty.call(
-      notificationSoundSelectionOverrides,
-      statusKey,
-    )
-  ) {
-    return;
-  }
-
   const rawSelection = notificationSoundSelections?.[statusKey];
   const trimmed = typeof rawSelection === "string" ? rawSelection.trim() : "";
   const normalized =
@@ -335,6 +325,17 @@ function playBrowserNotificationSound(statusKey) {
       : DEFAULT_NOTIFICATION_SOUND_SELECTIONS[statusKey];
 
   if (!normalized || !SOUND_FILE_SET.has(normalized)) {
+    return;
+  }
+
+  const defaultSelection = DEFAULT_NOTIFICATION_SOUND_SELECTIONS[statusKey];
+  const hasCustomSelection =
+    Object.prototype.hasOwnProperty.call(
+      notificationSoundSelectionOverrides,
+      statusKey,
+    ) || (defaultSelection ? normalized !== defaultSelection : false);
+
+  if (notificationDefaultSoundMuted && !hasCustomSelection) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure custom browser notification sounds still play when the default sound is muted by comparing the active selection against the default

## Testing
- not run (extension)


------
https://chatgpt.com/codex/tasks/task_e_68dbc60f9d88833397692b9249b64752