### PR TITLE
Mute default notification sound when preference enabled

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -375,12 +375,15 @@ async function showStatusNotification(task, statusKey) {
     : `Status changed to ${statusLabel}.`;
 
   try {
+    const muteDefaultSound = Boolean(notificationDefaultSoundMuted);
+
     const notificationId = await createNotification({
       type: "basic",
       iconUrl,
       title: `${statusLabel} task`,
       message,
       contextMessage: task?.url ? `${contextMessage} Click to open.` : contextMessage,
+      silent: muteDefaultSound,
     });
 
     if (notificationId && task?.url) {


### PR DESCRIPTION
## Summary
- respect the "Mute default notification sound" preference by creating notifications with the silent flag when it is enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbc9a8de1c8333b9b38de15ab97be8