### PR TITLE
Adjust notification sound handling

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -374,20 +374,28 @@ async function showStatusNotification(task, statusKey) {
     ? `Task ${taskId} is now ${statusLabel}.`
     : `Status changed to ${statusLabel}.`;
 
+  const notificationOptions = {
+    type: "basic",
+    iconUrl,
+    title: `${statusLabel} task`,
+    message,
+    contextMessage: task?.url ? `${contextMessage} Click to open.` : contextMessage,
+  };
+
+  if (notificationDefaultSoundMuted) {
+    notificationOptions.silent = true;
+  }
+
   try {
-    const notificationId = await createNotification({
-      type: "basic",
-      iconUrl,
-      title: `${statusLabel} task`,
-      message,
-      contextMessage: task?.url ? `${contextMessage} Click to open.` : contextMessage,
-    });
+    const notificationId = await createNotification(notificationOptions);
 
     if (notificationId && task?.url) {
       notificationTaskUrls.set(notificationId, task.url);
     }
 
-    playBrowserNotificationSound(statusKey);
+    if (notificationDefaultSoundMuted) {
+      playBrowserNotificationSound(statusKey);
+    }
   } catch (error) {
     console.error("Failed to create notification", error);
   }


### PR DESCRIPTION
## Summary
- add support for creating silent notifications when the default sound is muted in preferences
- prevent double chimes by only playing the custom sound when the default sound is muted

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68dbf01f66f88333a69978b306450d14