### PR TITLE
Remove default notification mute option

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -40,16 +40,6 @@ main {
   gap: 0.75rem;
 }
 
-.default-sound-setting {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.default-sound-setting .checkbox-option {
-  font-weight: 500;
-}
-
 .card-header h2 {
   margin: 0;
   font-size: 1.2rem;

--- a/src/options.html
+++ b/src/options.html
@@ -19,19 +19,6 @@
           Choose which task status changes should trigger a browser notification.
         </p>
         <form id="notification-preferences">
-          <div class="default-sound-setting">
-            <label class="checkbox-option" for="notification-default-sound-muted">
-              <input
-                type="checkbox"
-                name="notification-default-sound-muted"
-                id="notification-default-sound-muted"
-              />
-              Mute default notification sound
-            </label>
-            <p class="hint">
-              Stop playing the built-in sound until you pick a custom alert.
-            </p>
-          </div>
           <fieldset>
             <legend class="fieldset-title">
               Show a notification when a task becomes:


### PR DESCRIPTION
## Summary
- remove the "Mute default notification sound" control from the settings UI
- drop storage, event handling, and playback logic tied to the default mute flag
- clean up the options stylesheet now that the control is gone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dccf6a0eb48333bb25bbaeef180bfd