### PR TITLE
Remove mute default notification sound option

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -40,16 +40,6 @@ main {
   gap: 0.75rem;
 }
 
-.default-sound-setting {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.default-sound-setting .checkbox-option {
-  font-weight: 500;
-}
-
 .card-header h2 {
   margin: 0;
   font-size: 1.2rem;

--- a/src/options.html
+++ b/src/options.html
@@ -19,19 +19,6 @@
           Choose which task status changes should trigger a browser notification.
         </p>
         <form id="notification-preferences">
-          <div class="default-sound-setting">
-            <label class="checkbox-option" for="notification-default-sound-muted">
-              <input
-                type="checkbox"
-                name="notification-default-sound-muted"
-                id="notification-default-sound-muted"
-              />
-              Mute default notification sound
-            </label>
-            <p class="hint">
-              Stop playing the built-in sound until you pick a custom alert.
-            </p>
-          </div>
           <fieldset>
             <legend class="fieldset-title">
               Show a notification when a task becomes:

--- a/src/options.js
+++ b/src/options.js
@@ -12,8 +12,6 @@ const NOTIFICATION_SOUND_SELECTION_STORAGE_KEY =
   "codexNotificationSoundSelections";
 const NOTIFICATION_SOUND_ENABLED_STORAGE_KEY =
   "codexNotificationSoundEnabledStatuses";
-const NOTIFICATION_DEFAULT_SOUND_MUTED_STORAGE_KEY =
-  "codexNotificationDefaultSoundMuted";
 const DEFAULT_NOTIFICATION_STATUSES = ["ready", "pr-created"];
 const DEFAULT_NOTIFICATION_SOUND_SELECTIONS = {
   ready: "1.mp3",
@@ -21,7 +19,6 @@ const DEFAULT_NOTIFICATION_SOUND_SELECTIONS = {
   merged: "1.mp3",
 };
 const DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES = [...STATUS_OPTIONS];
-const DEFAULT_NOTIFICATION_DEFAULT_SOUND_MUTED = false;
 const STATUS_LABELS = {
   ready: "Task ready to view",
   "pr-created": "PR created",
@@ -479,7 +476,6 @@ async function handleEditPopupPositionClick() {
 }
 let cachedNotificationStatuses = [...DEFAULT_NOTIFICATION_STATUSES];
 let cachedSoundEnabledStatuses = [...DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES];
-let cachedDefaultSoundMuted = DEFAULT_NOTIFICATION_DEFAULT_SOUND_MUTED;
 
 function storageGet(key) {
   if (!storageApi?.local) {
@@ -593,33 +589,6 @@ function sanitizeSoundSelections(value) {
   return sanitized;
 }
 
-function sanitizeBoolean(value) {
-  if (value === true) {
-    return true;
-  }
-  if (value === false) {
-    return false;
-  }
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true") {
-      return true;
-    }
-    if (normalized === "false") {
-      return false;
-    }
-  }
-  if (typeof value === "number") {
-    if (value === 1) {
-      return true;
-    }
-    if (value === 0) {
-      return false;
-    }
-  }
-  return null;
-}
-
 function applyNotificationStatuses(statuses) {
   const form = document.getElementById("notification-preferences");
   if (!form) {
@@ -690,18 +659,6 @@ function applyNotificationSoundEnabledStatuses(statuses) {
   updateNotificationSoundSelectState();
 }
 
-function applyNotificationDefaultSoundMuted(isMuted) {
-  const checkbox = document.getElementById("notification-default-sound-muted");
-  if (!checkbox) {
-    return;
-  }
-
-  checkbox.checked = Boolean(isMuted);
-  cachedDefaultSoundMuted = Boolean(isMuted);
-  updateNotificationSoundToggleState();
-  updateNotificationSoundSelectState();
-}
-
 function updateNotificationSoundToggleState() {
   const form = document.getElementById("notification-preferences");
   if (!form) {
@@ -764,17 +721,12 @@ function showNotificationStatusMessage(message, isError = false) {
 
 async function loadNotificationPreferences() {
   try {
-    const [
-      storedStatuses,
-      storedSelections,
-      storedSoundEnabledStatuses,
-      storedDefaultSoundMuted,
-    ] = await Promise.all([
-      storageGet(NOTIFICATION_STATUS_STORAGE_KEY),
-      storageGet(NOTIFICATION_SOUND_SELECTION_STORAGE_KEY),
-      storageGet(NOTIFICATION_SOUND_ENABLED_STORAGE_KEY),
-      storageGet(NOTIFICATION_DEFAULT_SOUND_MUTED_STORAGE_KEY),
-    ]);
+    const [storedStatuses, storedSelections, storedSoundEnabledStatuses] =
+      await Promise.all([
+        storageGet(NOTIFICATION_STATUS_STORAGE_KEY),
+        storageGet(NOTIFICATION_SOUND_SELECTION_STORAGE_KEY),
+        storageGet(NOTIFICATION_SOUND_ENABLED_STORAGE_KEY),
+      ]);
     const sanitizedStatuses = sanitizeNotificationStatuses(storedStatuses);
     const statuses =
       sanitizedStatuses !== null ? sanitizedStatuses : DEFAULT_NOTIFICATION_STATUSES;
@@ -796,13 +748,6 @@ async function loadNotificationPreferences() {
         : DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES;
     applyNotificationSoundEnabledStatuses(soundEnabledStatuses);
 
-    const sanitizedDefaultMuted = sanitizeBoolean(storedDefaultSoundMuted);
-    const defaultMuted =
-      sanitizedDefaultMuted !== null
-        ? sanitizedDefaultMuted
-        : DEFAULT_NOTIFICATION_DEFAULT_SOUND_MUTED;
-    applyNotificationDefaultSoundMuted(defaultMuted);
-
     showNotificationStatusMessage("");
   } catch (error) {
     console.error("Unable to load notification preferences", error);
@@ -811,7 +756,6 @@ async function loadNotificationPreferences() {
     applyNotificationSoundEnabledStatuses(
       DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES,
     );
-    applyNotificationDefaultSoundMuted(DEFAULT_NOTIFICATION_DEFAULT_SOUND_MUTED);
     showNotificationStatusMessage(`Unable to load preferences: ${error.message}`, true);
   }
 }
@@ -1004,31 +948,6 @@ async function handleNotificationPreferencesChange(event) {
       }
     } catch (error) {
       console.error("Unable to save notification sound setting", error);
-      showNotificationStatusMessage(`Unable to save preferences: ${error.message}`, true);
-    }
-
-    return;
-  }
-
-  if (
-    target instanceof HTMLInputElement &&
-    target.name === "notification-default-sound-muted"
-  ) {
-    const isMuted = Boolean(target.checked);
-
-    try {
-      await storageSet(
-        NOTIFICATION_DEFAULT_SOUND_MUTED_STORAGE_KEY,
-        isMuted,
-      );
-      applyNotificationDefaultSoundMuted(isMuted);
-      showNotificationStatusMessage(
-        isMuted
-          ? "Default notification sound muted."
-          : "Default notification sound enabled.",
-      );
-    } catch (error) {
-      console.error("Unable to save default sound setting", error);
       showNotificationStatusMessage(`Unable to save preferences: ${error.message}`, true);
     }
 


### PR DESCRIPTION
## Summary
- remove the mute default notification sound checkbox from the settings page
- clean up related styles and storage logic that supported the muted state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcd11bba388333a8dc5b56b842b4a9