### PR TITLE
Auto-save popup colour preferences when updated

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -162,7 +162,6 @@
             <input type="color" id="popup-bg-color" name="popup-bg-color" />
             <label for="popup-text-color">Text colour</label>
             <input type="color" id="popup-text-color" name="popup-text-color" />
-            <button type="button" id="save-popup-colors-btn">Save colours</button>
           </div>
         </form>
         <p class="hint" id="popup-appearance-status" role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- auto-save the notification popup colour preferences when the inputs change
- remove the separate save button from the popup appearance controls

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68dcdc2873608333be3bea73606441ba