### PR TITLE
Fix popup preview saving by capturing bounds on click

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -152,8 +152,8 @@
         </div>
         <p class="hint">
           Adjust where the popup appears on screen, its size and colours. To set the
-          position and size, click <strong>Edit position and size</strong> and move the
-          preview window. Close the preview to save your changes.
+          position and size, click <strong>Edit position and size</strong>, move the
+          preview window, then click it to save your changes.
         </p>
         <form id="popup-appearance-form">
           <div class="popup-controls">


### PR DESCRIPTION
## Summary
- capture the preview window bounds when the notification is clicked in edit mode and relay them back to the options page before closing so the position is stored reliably
- register an options-page runtime listener to receive preview updates and keep cached bounds in sync while editing
- refresh the instructional text to tell users to click the preview to save their changes

## Testing
- not run (extension)

------
https://chatgpt.com/codex/tasks/task_e_68dced3f527483338dc2608ad7bffdc0