### PR TITLE
Add page background colour control

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -54,6 +54,7 @@ const DEFAULT_NOTIFICATION_POPUP_POSITION = { left: null, top: null };
 const DEFAULT_NOTIFICATION_POPUP_SIZE = { width: 360, height: 120 };
 const DEFAULT_NOTIFICATION_POPUP_COLORS = {
   background: "#f7fafc",
+  page: "#ffffff",
   text: "#1a1a1a",
 };
 let notificationPopupPosition = { ...DEFAULT_NOTIFICATION_POPUP_POSITION };
@@ -235,7 +236,7 @@ function sanitizePopupSize(value) {
 
 /**
  * Sanitize a stored popup colour configuration. Accepts objects with
- * `background` and `text` properties. Each value must be a valid CSS
+ * `background`, `page`, and `text` properties. Each value must be a valid CSS
  * colour string (we only accept hex colours like #rrggbb). Returns null
  * if the input is invalid.
  *
@@ -249,6 +250,9 @@ function sanitizePopupColors(value) {
   const result = {};
   if (typeof value.background === "string" && hexRegex.test(value.background)) {
     result.background = value.background;
+  }
+  if (typeof value.page === "string" && hexRegex.test(value.page)) {
+    result.page = value.page;
   }
   if (typeof value.text === "string" && hexRegex.test(value.text)) {
     result.text = value.text;
@@ -551,6 +555,9 @@ async function showStatusNotification(task, statusKey) {
   // have been added so they are included in the final URL.
   if (notificationPopupColors?.background) {
     params.set("bg", notificationPopupColors.background);
+  }
+  if (notificationPopupColors?.page) {
+    params.set("page", notificationPopupColors.page);
   }
   if (notificationPopupColors?.text) {
     params.set("text", notificationPopupColors.text);

--- a/src/custom-notification.js
+++ b/src/custom-notification.js
@@ -12,13 +12,24 @@
       audio: params.get("audio") || "",
       clickUrl: params.get("clickUrl") || "",
       bgColor: params.get("bg") || "",
+      pageColor: params.get("page") || "",
       textColor: params.get("text") || "",
       edit: params.get("edit") === "1" || params.get("edit") === "true",
       sessionId: params.get("session") || "",
     };
   }
 
-  const { title, message, audio, clickUrl, bgColor, textColor, edit, sessionId } =
+  const {
+    title,
+    message,
+    audio,
+    clickUrl,
+    bgColor,
+    pageColor,
+    textColor,
+    edit,
+    sessionId,
+  } =
     getQueryParams();
 
   // Populate the notification title and message elements. Using innerText
@@ -28,9 +39,14 @@
   if (titleEl) titleEl.innerText = title;
   if (messageEl) messageEl.innerText = message;
 
-  // Apply custom colours if provided. The caller can pass `bg` and `text` query
-  // parameters containing CSS colour values (e.g. "#ffffff"). These values
-  // override the default appearance of the notification container.
+  // Apply custom colours if provided. The caller can pass `bg`, `page`, and
+  // `text` query parameters containing CSS colour values (e.g. "#ffffff"). These
+  // values override the default appearance of the notification container and
+  // surrounding page.
+  if (pageColor) {
+    document.documentElement.style.backgroundColor = pageColor;
+    document.body.style.backgroundColor = pageColor;
+  }
   const rootEl = document.getElementById("notification-root");
   if (rootEl) {
     if (bgColor) {

--- a/src/options.html
+++ b/src/options.html
@@ -158,8 +158,10 @@
         <form id="popup-appearance-form">
           <div class="popup-controls">
             <button type="button" id="edit-popup-position-btn">Edit position and size</button>
-            <label for="popup-bg-color">Background colour</label>
+            <label for="popup-bg-color">Button background</label>
             <input type="color" id="popup-bg-color" name="popup-bg-color" />
+            <label for="popup-page-color">Page background</label>
+            <input type="color" id="popup-page-color" name="popup-page-color" />
             <label for="popup-text-color">Text colour</label>
             <input type="color" id="popup-text-color" name="popup-text-color" />
           </div>

--- a/src/options.js
+++ b/src/options.js
@@ -91,6 +91,7 @@ const DEFAULT_NOTIFICATION_POPUP_POSITION = { left: null, top: null };
 const DEFAULT_NOTIFICATION_POPUP_SIZE = { width: 360, height: 120 };
 const DEFAULT_NOTIFICATION_POPUP_COLORS = {
   background: "#f7fafc",
+  page: "#ffffff",
   text: "#1a1a1a",
 };
 
@@ -168,9 +169,9 @@ function sanitizePopupSizeOption(value) {
 
 /**
  * Sanitize a stored popup colour configuration. Accepts objects with
- * `background` and `text` properties. Each value must be a valid CSS
+ * `background`, `page`, and `text` properties. Each value must be a valid CSS
  * hex colour string (e.g. "#ffffff" or "#abc"). Returns null if the
- * input is invalid or missing both values.
+ * input is invalid or missing all values.
  *
  * @param {any} value
  * @returns {object|null}
@@ -183,6 +184,9 @@ function sanitizePopupColorOption(value) {
   const result = {};
   if (typeof value.background === "string" && hexRegex.test(value.background)) {
     result.background = value.background;
+  }
+  if (typeof value.page === "string" && hexRegex.test(value.page)) {
+    result.page = value.page;
   }
   if (typeof value.text === "string" && hexRegex.test(value.text)) {
     result.text = value.text;
@@ -198,10 +202,15 @@ function sanitizePopupColorOption(value) {
  */
 function applyPopupColorInputs() {
   const bgInput = document.getElementById("popup-bg-color");
+  const pageInput = document.getElementById("popup-page-color");
   const textInput = document.getElementById("popup-text-color");
   if (bgInput) {
     bgInput.value =
       cachedPopupColors?.background || DEFAULT_NOTIFICATION_POPUP_COLORS.background;
+  }
+  if (pageInput) {
+    pageInput.value =
+      cachedPopupColors?.page || DEFAULT_NOTIFICATION_POPUP_COLORS.page;
   }
   if (textInput) {
     textInput.value =
@@ -278,16 +287,21 @@ async function loadPopupAppearancePreferences() {
  */
 async function handlePopupColorChange() {
   const bgInput = document.getElementById("popup-bg-color");
+  const pageInput = document.getElementById("popup-page-color");
   const textInput = document.getElementById("popup-text-color");
   const statusEl = document.getElementById("popup-appearance-status");
-  if (!bgInput || !textInput) {
+  if (!bgInput || !pageInput || !textInput) {
     return;
   }
   const bgValue = String(bgInput.value || "").trim();
+  const pageValue = String(pageInput.value || "").trim();
   const textValue = String(textInput.value || "").trim();
   const colorsToStore = {};
   if (bgValue) {
     colorsToStore.background = bgValue;
+  }
+  if (pageValue) {
+    colorsToStore.page = pageValue;
   }
   if (textValue) {
     colorsToStore.text = textValue;
@@ -298,6 +312,7 @@ async function handlePopupColorChange() {
   };
   if (
     cachedPopupColors.background === normalizedColors.background &&
+    cachedPopupColors.page === normalizedColors.page &&
     cachedPopupColors.text === normalizedColors.text
   ) {
     return;
@@ -354,6 +369,9 @@ async function handleEditPopupPositionClick() {
   // appearance. These override the defaults in the notification page.
   if (cachedPopupColors?.background) {
     params.set("bg", cachedPopupColors.background);
+  }
+  if (cachedPopupColors?.page) {
+    params.set("page", cachedPopupColors.page);
   }
   if (cachedPopupColors?.text) {
     params.set("text", cachedPopupColors.text);


### PR DESCRIPTION
## Summary
- rename the popup background label to clarify it controls the button colour
- add a configurable page background colour alongside the existing popup colours
- plumb the new colour through the notification preview and live popup rendering

## Testing
- Manual verification in the browser options page

------
https://chatgpt.com/codex/tasks/task_e_68dcef87b3ac833388e1123f86c3cae7