### PR TITLE
Center preview heading text

### DIFF
--- a/src/custom-notification.html
+++ b/src/custom-notification.html
@@ -28,6 +28,7 @@
         background-color: #f7fafc;
         border: 1px solid #e2e8f0;
         cursor: pointer;
+        text-align: center;
       }
       .notification h1 {
         margin: 0 0 4px 0;


### PR DESCRIPTION
## Summary
- center the preview notification content so the title text is centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf3efd0588333b0c5645990bfaf26