### PR TITLE
Adjust layout of popup colour controls

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -166,17 +166,31 @@ main {
 /* Popup appearance controls */
 .popup-controls {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.popup-colour-settings {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 0.5rem 0.75rem;
   align-items: center;
 }
 
-.popup-controls label {
+.popup-colour-heading {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1f2937;
+  grid-column: 1 / -1;
+}
+
+.popup-colour-settings label {
   font-size: 0.9rem;
   color: #475569;
 }
 
-.popup-controls input[type="color"] {
+.popup-colour-settings input[type="color"] {
   width: 2.5rem;
   height: 2rem;
   border: none;

--- a/src/options.html
+++ b/src/options.html
@@ -158,12 +158,15 @@
         <form id="popup-appearance-form">
           <div class="popup-controls">
             <button type="button" id="edit-popup-position-btn">Edit position and size</button>
-            <label for="popup-bg-color">Button background</label>
-            <input type="color" id="popup-bg-color" name="popup-bg-color" />
-            <label for="popup-page-color">Page background</label>
-            <input type="color" id="popup-page-color" name="popup-page-color" />
-            <label for="popup-text-color">Text colour</label>
-            <input type="color" id="popup-text-color" name="popup-text-color" />
+            <div class="popup-colour-settings">
+              <span class="popup-colour-heading">Popup colours:</span>
+              <label for="popup-bg-color">Button background</label>
+              <input type="color" id="popup-bg-color" name="popup-bg-color" />
+              <label for="popup-page-color">Page background</label>
+              <input type="color" id="popup-page-color" name="popup-page-color" />
+              <label for="popup-text-color">Text colour</label>
+              <input type="color" id="popup-text-color" name="popup-text-color" />
+            </div>
           </div>
         </form>
         <p class="hint" id="popup-appearance-status" role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- move the popup colour selectors into their own grouped row beneath the edit button
- style the colour controls with a heading and grid layout for clearer spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcf5c215c483339c08ca517065b880