### PR TITLE
Align popup colour controls and refresh status wording

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -171,21 +171,25 @@ main {
   align-items: flex-start;
 }
 
+
 .popup-colour-settings {
-  display: grid;
-  grid-template-columns: auto auto;
-  gap: 0.5rem 0.75rem;
+  display: flex;
   align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .popup-colour-heading {
   font-size: 0.9rem;
   font-weight: 600;
   color: #1f2937;
-  grid-column: 1 / -1;
+  margin-right: 0.25rem;
 }
 
-.popup-colour-settings label {
+.popup-colour-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   font-size: 0.9rem;
   color: #475569;
 }

--- a/src/options.html
+++ b/src/options.html
@@ -160,12 +160,18 @@
             <button type="button" id="edit-popup-position-btn">Edit position and size</button>
             <div class="popup-colour-settings">
               <span class="popup-colour-heading">Popup colours:</span>
-              <label for="popup-bg-color">Button</label>
-              <input type="color" id="popup-bg-color" name="popup-bg-color" />
-              <label for="popup-page-color">Background</label>
-              <input type="color" id="popup-page-color" name="popup-page-color" />
-              <label for="popup-text-color">Text</label>
-              <input type="color" id="popup-text-color" name="popup-text-color" />
+              <label class="popup-colour-option" for="popup-bg-color">
+                Button
+                <input type="color" id="popup-bg-color" name="popup-bg-color" />
+              </label>
+              <label class="popup-colour-option" for="popup-page-color">
+                Background
+                <input type="color" id="popup-page-color" name="popup-page-color" />
+              </label>
+              <label class="popup-colour-option" for="popup-text-color">
+                Text
+                <input type="color" id="popup-text-color" name="popup-text-color" />
+              </label>
             </div>
           </div>
         </form>

--- a/src/options.js
+++ b/src/options.js
@@ -466,7 +466,7 @@ async function handleEditPopupPositionClick() {
           ...sizeToStore,
         };
         if (showSuccessMessage && statusEl) {
-          statusEl.textContent = "Popup position and size saved.";
+          statusEl.textContent = "Popup position and size updated.";
           statusEl.classList.remove("error");
         }
       } catch (err) {
@@ -594,7 +594,7 @@ async function handleEditPopupPositionClick() {
       windowsApi.onBoundsChanged.addListener(boundsListener);
     } else {
       console.warn(
-        "windows.onBoundsChanged API not available; popup position will only be saved when the window closes.",
+        "windows.onBoundsChanged API not available; popup position will only be stored when the window closes.",
       );
     }
     // Listener for when the preview window is closed. Finalise the
@@ -1073,7 +1073,7 @@ async function handleNotificationPreferencesChange(event) {
       await storageSet(NOTIFICATION_STATUS_STORAGE_KEY, statusesToStore);
       applyNotificationStatuses(statusesToStore);
       if (statusesToStore.length) {
-        showNotificationStatusMessage("Preferences saved.");
+        showNotificationStatusMessage("Preferences updated.");
       } else {
         showNotificationStatusMessage("Browser notifications are disabled.");
       }
@@ -1111,7 +1111,7 @@ async function handleNotificationPreferencesChange(event) {
             : `${label} sound disabled.`,
         );
       } else {
-        showNotificationStatusMessage("Sound preference saved.");
+        showNotificationStatusMessage("Sound preference updated.");
       }
     } catch (error) {
       console.error("Unable to save notification sound setting", error);
@@ -1137,7 +1137,7 @@ async function handleNotificationPreferencesChange(event) {
         selectionsToStore,
       );
       applyNotificationSoundSelections(selectionsToStore);
-      showNotificationStatusMessage("Sound choice saved.");
+      showNotificationStatusMessage("Sound choice updated.");
     } catch (error) {
       console.error("Unable to save notification sound selection", error);
       showNotificationStatusMessage(`Unable to save preferences: ${error.message}`, true);


### PR DESCRIPTION
## Summary
- display the popup colour selectors inline with their heading for a single-row layout
- replace option status copy that referenced values being "saved" with updated terminology

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd24b9dae08333b7afcf71b1f4f7b6