### PR TITLE
Update default notification popup colours

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -53,9 +53,9 @@ const NOTIFICATION_POPUP_COLORS_STORAGE_KEY = "codexNotificationPopupColors";
 const DEFAULT_NOTIFICATION_POPUP_POSITION = { left: null, top: null };
 const DEFAULT_NOTIFICATION_POPUP_SIZE = { width: 360, height: 120 };
 const DEFAULT_NOTIFICATION_POPUP_COLORS = {
-  background: "#f7fafc",
-  page: "#ffffff",
-  text: "#1a1a1a",
+  background: "#1d4ed8",
+  page: "#1f2937",
+  text: "#22c55e",
 };
 let notificationPopupPosition = { ...DEFAULT_NOTIFICATION_POPUP_POSITION };
 let notificationPopupSize = { ...DEFAULT_NOTIFICATION_POPUP_SIZE };

--- a/src/custom-notification.html
+++ b/src/custom-notification.html
@@ -11,8 +11,8 @@
         margin: 0;
         padding: 0;
         font-family: sans-serif;
-        background-color: #ffffff;
-        color: #1a1a1a;
+        background-color: #1f2937;
+        color: #22c55e;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -25,8 +25,8 @@
         padding: 12px 16px;
         border-radius: 8px;
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-        background-color: #f7fafc;
-        border: 1px solid #e2e8f0;
+        background-color: #1d4ed8;
+        border: 1px solid #1e40af;
         cursor: pointer;
         text-align: center;
       }

--- a/src/options.js
+++ b/src/options.js
@@ -90,9 +90,9 @@ const NOTIFICATION_POPUP_COLORS_STORAGE_KEY = "codexNotificationPopupColors";
 const DEFAULT_NOTIFICATION_POPUP_POSITION = { left: null, top: null };
 const DEFAULT_NOTIFICATION_POPUP_SIZE = { width: 360, height: 120 };
 const DEFAULT_NOTIFICATION_POPUP_COLORS = {
-  background: "#f7fafc",
-  page: "#ffffff",
-  text: "#1a1a1a",
+  background: "#1d4ed8",
+  page: "#1f2937",
+  text: "#22c55e",
 };
 
 // Cached popup appearance values. These are populated from storage on


### PR DESCRIPTION
## Summary
- set the default notification popup colours to the new blue, charcoal and green palette in both the background script and options page
- update the custom notification template so its fallback styling matches the new default palette

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd265909bc8333950f27b792aaae01