### PR TITLE
Rename PR created label to PR ready to view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.1.23 - 2025-09-30
+
+- Renamed the **PR created** status label to **PR ready to view** across the
+  extension, ensuring notifications, logs, and settings all reflect the updated
+  wording.
+
 # 1.1.22 - 2025-09-30
 
 - **Manifest fix for Firefox:** The previous release added a `windows` permission
@@ -106,16 +112,16 @@
 - Added Firefox toolbar icon assets and wired them up in the manifest so the button renders again.
 
 # 1.1.4 - 2025-09-28
-- Restore automatic handling of ready Codex tasks by opening them in a new tab and marking them as PR created without opening the popup.
+- Restore automatic handling of ready Codex tasks by opening them in a new tab and marking them as PR ready to view without opening the popup.
 
 # 1.1.3 - 2025-09-28
 - Automatically click the Codex **Create PR** button after opening ready tasks in a new tab.
 
 # 1.1.2 - 2025-09-28
-- Automated the **Create PR** action for ready tasks and update their status to **PR created** when successful.
+- Automated the **Create PR** action for ready tasks and update their status to **PR ready to view** when successful.
 
 # 1.1.1 - 2025-09-28
-- Added popup actions to open ready tasks, trigger the "Create PR" workflow, and mark the status as PR created.
+- Added popup actions to open ready tasks, trigger the "Create PR" workflow, and mark the status as PR ready to view.
 - Introduced new styling for task actions and status badges.
 - Granted the extension permission to open task links in new tabs.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the codex-autorun Firefox-compatible WebExtension with 
 
 ## Popup workflow
 
-When a tracked task leaves the "working" state, the popup now highlights it as **Task ready to view** and provides a **Create PR** action. Clicking the button opens the original task link in a new tab and marks the stored status as **PR created** so you can track which tasks already have pull requests in flight. All other tasks expose an **Open task** action for quick access to their Codex links.
+When a tracked task leaves the "working" state, the popup now highlights it as **Task ready to view** and provides a **Create PR** action. Clicking the button opens the original task link in a new tab and marks the stored status as **PR ready to view** so you can track which tasks already have pull requests in flight. All other tasks expose an **Open task** action for quick access to their Codex links.
 
 ## Load the extension in Firefox
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/background.js
+++ b/src/background.js
@@ -87,7 +87,7 @@ const IGNORED_NAME_PATTERNS = [
 ];
 const STATUS_LABELS = {
   ready: "Task ready to view",
-  "pr-created": "PR created",
+  "pr-created": "PR ready to view",
   merged: "Merged",
 };
 
@@ -1190,7 +1190,7 @@ async function markTaskAsPrCreated(task) {
   const nextHistory = [...history];
   nextHistory[index] = updated;
   await storageSet(HISTORY_KEY, nextHistory);
-  console.log("Marked Codex task as PR created", updated);
+  console.log("Marked Codex task as PR ready to view", updated);
 }
 
 async function autoHandleReadyTask(task) {

--- a/src/options.html
+++ b/src/options.html
@@ -60,7 +60,7 @@
               <div class="sound-option">
                 <label class="checkbox-option">
                   <input type="checkbox" name="notification-status" value="pr-created" />
-                  PR created
+                  PR ready to view
                 </label>
                 <div class="sound-controls">
                   <label class="sound-toggle">

--- a/src/options.js
+++ b/src/options.js
@@ -64,7 +64,7 @@ const DEFAULT_NOTIFICATION_SOUND_SELECTIONS = {
 const DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES = [...STATUS_OPTIONS];
 const STATUS_LABELS = {
   ready: "Task ready to view",
-  "pr-created": "PR created",
+  "pr-created": "PR ready to view",
   merged: "Merged",
 };
 const SOUND_FILE_OPTIONS = [

--- a/src/popup.js
+++ b/src/popup.js
@@ -445,7 +445,7 @@ function formatStatusLabel(status) {
     return "Working";
   }
   if (normalized.toLowerCase() === "pr-created") {
-    return "PR created";
+    return "PR ready to view";
   }
   const words = normalized
     .replace(/[_-]+/g, " ")


### PR DESCRIPTION
## Summary
- rename the "PR created" status label across the extension UI and logs to "PR ready to view"
- update documentation and changelog to reflect the new wording and bump the extension version

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd3456c2a88333a28bdce0cbe08907