### PR TITLE
Add placeholder test4.txt asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.1.24 - 2025-09-30
+
+- Added `test4.txt`, a placeholder text asset used to verify repository
+  updates that include simple documentation files.
+
 # 1.1.23 - 2025-09-30
 
 - Renamed the **PR created** status label to **PR ready to view** across the

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/test4.txt
+++ b/test4.txt
@@ -1,0 +1,4 @@
+Test file 4
+==========
+
+This placeholder file exists so automated checks can confirm that text-only assets are properly tracked in the repository.


### PR DESCRIPTION
## Summary
- add a placeholder `test4.txt` text asset for repository validation
- document the addition in the changelog and bump the extension version to 1.1.24

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2ada8c388333855452d05bae66e8