### PR TITLE
Add GitHub merge automation support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "tabs",
     "notifications",
     "https://chatgpt.com/*",
-    "https://debuggpt.tools/*"
+    "https://debuggpt.tools/*",
+    "https://github.com/*"
   ],
   "icons": {
     "16": "src/icons/icon-16.png",
@@ -40,7 +41,11 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://chatgpt.com/*", "https://debuggpt.tools/*"],
+      "matches": [
+        "https://chatgpt.com/*",
+        "https://debuggpt.tools/*",
+        "https://github.com/*"
+      ],
       "js": ["src/codexWatcher.js"],
       "run_at": "document_idle"
     }

--- a/src/options.css
+++ b/src/options.css
@@ -122,11 +122,13 @@ main {
   color: #64748b;
 }
 
-#notification-status-message {
+#notification-status-message,
+#automation-status-message {
   min-height: 1.25rem;
 }
 
-#notification-status-message.error {
+#notification-status-message.error,
+#automation-status-message.error {
   color: #b91c1c;
 }
 

--- a/src/options.html
+++ b/src/options.html
@@ -145,6 +145,31 @@
         </div>
       </section>
 
+      <section class="card" aria-labelledby="automation-preferences-title">
+        <div class="card-header">
+          <h2 id="automation-preferences-title">Automation</h2>
+        </div>
+        <p class="hint">
+          Automatically click workflow buttons after Codex finishes a task.
+        </p>
+        <form id="automation-preferences">
+          <label class="checkbox-option">
+            <input
+              type="checkbox"
+              id="auto-merge-enabled"
+              name="auto-merge-enabled"
+            />
+            Auto-click &ldquo;Merge pull request&rdquo; button
+          </label>
+        </form>
+        <p
+          class="hint"
+          id="automation-status-message"
+          role="status"
+          aria-live="polite"
+        ></p>
+      </section>
+
       <!-- Popup appearance configuration -->
       <section class="card" aria-labelledby="popup-appearance-title">
         <div class="card-header">


### PR DESCRIPTION
## Summary
- add a settings toggle to enable automatically clicking the "Merge pull request" button
- extend the content script to run on GitHub, load the preference, and click merge/confirm when enabled

## Testing
- not run (extension)

------
https://chatgpt.com/codex/tasks/task_e_68e00a7668dc8333a4b39416f5f0bab5