### PR TITLE
Include pr-ready status in default auto-click settings

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -36,15 +36,15 @@ const NOTIFICATION_DEFAULT_SOUND_MUTED_STORAGE_KEY =
 // cause the extension to automatically open the task and (if enabled) create
 // a pull request when a task becomes ready. Enabling "pr-created" will
 // perform any follow-up actions after a PR is created (such as scheduling
-// the pr-ready notification). "pr-ready" currently has no auto-click
-// behaviour implemented but is exposed for future use. "merged" has no
-// auto-click behaviour and is ignored.
+// the pr-ready notification). Enabling "pr-ready" will auto-click the
+// "View PR" button when a pull request becomes ready to view. "merged" has
+// no auto-click behaviour and is ignored.
 const AUTO_CLICK_STATUS_STORAGE_KEY = "codexAutoClickStatuses";
 
-// By default automatically handle tasks becoming ready and PRs being
-// created. Users can disable auto-click on a per-status basis in the
-// settings.
-const DEFAULT_AUTO_CLICK_STATUSES = ["ready", "pr-created"];
+// By default automatically handle tasks becoming ready, PRs being created and
+// PRs becoming ready to view. Users can disable auto-click on a per-status
+// basis in the settings.
+const DEFAULT_AUTO_CLICK_STATUSES = ["ready", "pr-created", "pr-ready"];
 
 // In-memory set of statuses for which auto-click behaviour is enabled.
 let autoClickEnabledStatuses = new Set(DEFAULT_AUTO_CLICK_STATUSES);

--- a/src/codexWatcher.js
+++ b/src/codexWatcher.js
@@ -1098,7 +1098,7 @@ function setupCreatePrAutoClick() {
     (typeof browser !== "undefined" && browser?.storage) ||
     (typeof chrome !== "undefined" && chrome?.storage);
   const AUTO_CLICK_STATUS_STORAGE_KEY = "codexAutoClickStatuses";
-  const DEFAULT_AUTO_CLICK_STATUSES = ["ready", "pr-created"];
+  const DEFAULT_AUTO_CLICK_STATUSES = ["ready", "pr-created", "pr-ready"];
   const applyAutoClick = (enabled) => {
     if (!enabled) {
       return; // Do nothing if auto-click is disabled for pr-created
@@ -1223,7 +1223,7 @@ function setupViewPrAutoClick() {
     (typeof browser !== "undefined" && browser?.storage) ||
     (typeof chrome !== "undefined" && chrome?.storage);
   const AUTO_CLICK_STATUS_STORAGE_KEY = "codexAutoClickStatuses";
-  const DEFAULT_AUTO_CLICK_STATUSES = ["ready", "pr-created"];
+  const DEFAULT_AUTO_CLICK_STATUSES = ["ready", "pr-created", "pr-ready"];
 
   // Storage key and default for the delay before auto-clicking the
   // "View PR" button. This mirrors the key defined in the options


### PR DESCRIPTION
## Summary
- include the pr-ready status in the background script's default auto-click configuration to match the UI
- ensure the codex watcher fallback defaults also include pr-ready so the View PR action auto-clicks without saved preferences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e016c3bcbc8333aa1f1f28c2d3269d