### PR TITLE
Align GitHub merge auto-click defaults with options settings

### DIFF
--- a/src/ghMergeWatcher.js
+++ b/src/ghMergeWatcher.js
@@ -30,10 +30,12 @@
   const CLOSE_GITHUB_AFTER_MERGE_KEY = "codexCloseGithubAfterMergeEnabled";
 
   // Default values when storage is unavailable or preferences are
-  // missing. All options default to false (no auto-click).
-  const DEFAULT_MERGE_PR_AUTO_CLICK = false;
-  const DEFAULT_CONFIRM_MERGE_AUTO_CLICK = false;
-  const DEFAULT_CLOSE_AFTER = false;
+  // missing. These defaults should mirror the values exposed in the
+  // options UI (see options.js). All GitHub merge automation toggles
+  // default to true so the feature works out of the box.
+  const DEFAULT_MERGE_PR_AUTO_CLICK = true;
+  const DEFAULT_CONFIRM_MERGE_AUTO_CLICK = true;
+  const DEFAULT_CLOSE_AFTER = true;
 
   let mergePrEnabled = DEFAULT_MERGE_PR_AUTO_CLICK;
   let confirmMergeEnabled = DEFAULT_CONFIRM_MERGE_AUTO_CLICK;


### PR DESCRIPTION
## Summary
- align the GitHub merge automation content script defaults with the options UI
- ensure the merge, confirm, and close-after-merge toggles default to enabled when storage is empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0182300f883339b8b7eec80f1799f