### PR TITLE
Add manual override for GitHub merge automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 1.1.39 - 2025-10-02
+
+* **Manual override for GitHub merge automation:** The GitHub content script
+  now listens for user interactions—mouse clicks, scrolling and key
+  presses—before automatically merging a pull request. If any interaction is
+  detected, the script cancels further auto-clicking (including the optional
+  post-merge tab close) for the current page load so you can finish the merge
+  manually.
+
+* **Version bumped to 1.1.39.**
+
 # 1.1.38 - 2025-10-02
 
 * **Simplified status table:** Removed the “Merged” row from the

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary
- allow manual merges by cancelling GitHub auto-clicks when the user interacts with the page
- stop merge and confirm polling when automation is cancelled and skip closing the tab
- document the behaviour change in the changelog and bump the extension version to 1.1.39

## Testing
- not run (web extension code change)


------
https://chatgpt.com/codex/tasks/task_e_68e019ef56708333b8614e574b499352