### PR TITLE
Support manual GitHub status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 1.1.39 - 2025-10-02
+
+* **Support additional task statuses:** Expanded the recognised status list to
+  include GitHub’s **Open** and **Closed** states alongside the existing
+  **Merged** status so manual updates on GitHub flow back into the extension’s
+  history and notifications.
+* **Popup styling for new statuses:** Added dedicated badge styles and labels
+  for the new states so they appear with clear colours in the popup.
+* **Version bumped to 1.1.39.**
+
 # 1.1.38 - 2025-10-02
 
 * **Simplified status table:** Removed the “Merged” row from the

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/background.js
+++ b/src/background.js
@@ -61,13 +61,17 @@ const DEFAULT_NOTIFICATION_SOUND_SELECTIONS = {
   ready: "1.mp3",
   "pr-created": "2.mp3",
   "pr-ready": "3.mp3",
+  open: "2.mp3",
   merged: "1.mp3",
+  closed: "4.mp3",
 };
 const DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES = [
   "ready",
   "pr-created",
   "pr-ready",
+  "open",
   "merged",
+  "closed",
 ];
 
 // -----------------------------------------------------------------------------
@@ -189,7 +193,14 @@ const SOUND_FILE_OPTIONS = [
   "8.mp3",
 ];
 const SOUND_FILE_SET = new Set(SOUND_FILE_OPTIONS);
-const STATUS_VALUE_SET = new Set(["ready", "pr-created", "pr-ready", "merged"]);
+const STATUS_VALUE_SET = new Set([
+  "ready",
+  "pr-created",
+  "pr-ready",
+  "open",
+  "merged",
+  "closed",
+]);
 let notificationEnabledStatuses = new Set(DEFAULT_NOTIFICATION_STATUSES);
 let notificationSoundSelectionOverrides = {};
 let notificationSoundSelections = { ...DEFAULT_NOTIFICATION_SOUND_SELECTIONS };
@@ -212,7 +223,9 @@ const STATUS_LABELS = {
   // Label for the new PR ready status. Displayed in notifications and
   // settings.
   "pr-ready": "PR ready to view",
+  open: "Open",
   merged: "Merged",
+  closed: "Closed",
   "other status": "Other status",
   working: "Working on task",
 };
@@ -1248,7 +1261,14 @@ async function appendHistory(task) {
   console.log("Tracked codex task", entry);
 }
 
-const COMPLETED_STATUS_KEYS = new Set(["ready", "pr-created", "pr-ready", "merged"]);
+const COMPLETED_STATUS_KEYS = new Set([
+  "ready",
+  "pr-created",
+  "pr-ready",
+  "open",
+  "merged",
+  "closed",
+]);
 
 async function updateHistory(task) {
   const id = normalizeTaskId(task?.id);

--- a/src/options.js
+++ b/src/options.js
@@ -51,7 +51,14 @@ if (runtimeApi?.onMessage && typeof runtimeApi.onMessage.addListener === "functi
 // Include the new "pr-ready" status representing a pull request that is
 // ready to view. This array controls the order of statuses displayed in
 // the settings and is used to derive default sound enablement.
-const STATUS_OPTIONS = ["ready", "pr-created", "pr-ready", "merged"];
+const STATUS_OPTIONS = [
+  "ready",
+  "pr-created",
+  "pr-ready",
+  "open",
+  "merged",
+  "closed",
+];
 const STATUS_VALUES = new Set(STATUS_OPTIONS);
 const NOTIFICATION_STATUS_STORAGE_KEY = "codexNotificationStatuses";
 const NOTIFICATION_SOUND_SELECTION_STORAGE_KEY =
@@ -65,12 +72,15 @@ const DEFAULT_NOTIFICATION_STATUSES = ["ready", "pr-created", "pr-ready"];
 const DEFAULT_NOTIFICATION_SOUND_SELECTIONS = {
   // Use distinct default sounds for each status to provide clear
   // differentiation. The first status plays Sound 1 by default, PR
-  // creation plays Sound 2, PR ready plays Sound 3 and merged reuses
-  // Sound 1. Users can change these selections in the UI.
+  // creation plays Sound 2, PR ready plays Sound 3, the open state reuses
+  // Sound 2, merged reuses Sound 1 and closed uses Sound 4. Users can
+  // change these selections in the UI.
   ready: "1.mp3",
   "pr-created": "2.mp3",
   "pr-ready": "3.mp3",
+  open: "2.mp3",
   merged: "1.mp3",
+  closed: "4.mp3",
 };
 const DEFAULT_NOTIFICATION_SOUND_ENABLED_STATUSES = [...STATUS_OPTIONS];
 const STATUS_LABELS = {
@@ -79,7 +89,9 @@ const STATUS_LABELS = {
   // Human‑friendly label for the PR ready status.
   // Shortened label to fit on a single line.
   "pr-ready": "PR ready to view",
+  open: "Open",
   merged: "Merged",
+  closed: "Closed",
 };
 const SOUND_FILE_OPTIONS = [
   "1.mp3",

--- a/src/popup.css
+++ b/src/popup.css
@@ -251,9 +251,19 @@ button:disabled {
   color: #5b21b6;
 }
 
+.task-status--open {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
 .task-status--merged {
   background: #bbf7d0;
   color: #166534;
+}
+
+.task-status--closed {
+  background: #fee2e2;
+  color: #b91c1c;
 }
 
 .task-status--working {

--- a/src/popup.js
+++ b/src/popup.js
@@ -27,7 +27,14 @@ const lastKnownTaskStatuses = new Map();
 // active task list and stops related actions from being available. To
 // keep the popup in sync with the background logic we include "pr-ready"
 // alongside the existing completion statuses.
-const COMPLETED_STATUS_KEYS = new Set(["ready", "pr-created", "pr-ready", "merged"]);
+const COMPLETED_STATUS_KEYS = new Set([
+  "ready",
+  "pr-created",
+  "pr-ready",
+  "open",
+  "merged",
+  "closed",
+]);
 
 // When a task transitions through various lifecycle states the extension
 // can play notification sounds. The original implementation only
@@ -38,7 +45,14 @@ const COMPLETED_STATUS_KEYS = new Set(["ready", "pr-created", "pr-ready", "merge
 // include "pr-ready", update the defaults accordingly and include it in
 // the validation set. Users can now customise the sound (or mute it) for
 // this status via the options page.
-const SOUND_STATUSES = ["ready", "pr-created", "pr-ready", "merged"];
+const SOUND_STATUSES = [
+  "ready",
+  "pr-created",
+  "pr-ready",
+  "open",
+  "merged",
+  "closed",
+];
 const SOUND_STATUS_STORAGE_KEY = "codexSoundStatuses";
 const SOUND_SELECTION_STORAGE_KEY = "codexSoundSelections";
 // By default play sounds for all available statuses. Previously only
@@ -50,16 +64,20 @@ const DEFAULT_SOUND_STATUSES = [
   "ready",
   "pr-created",
   "pr-ready",
+  "open",
   "merged",
+  "closed",
 ];
 const DEFAULT_SOUND_SELECTIONS = {
   ready: "1.mp3",
-  "pr-created": "1.mp3",
+  "pr-created": "2.mp3",
   // Default audio file for the PR ready status. Using the same file
   // avoids unexpected changes for users upgrading from earlier versions
   // where no sound was played for this status.
-  "pr-ready": "1.mp3",
+  "pr-ready": "3.mp3",
+  open: "2.mp3",
   merged: "1.mp3",
+  closed: "4.mp3",
 };
 const STATUS_DISPLAY = {
   working: {
@@ -82,10 +100,20 @@ const STATUS_DISPLAY = {
     description: "PR ready to view",
     className: "task-status--pr-ready",
   },
+  open: {
+    badge: "Open",
+    description: "PR open",
+    className: "task-status--open",
+  },
   merged: {
     badge: "Merged",
     description: "Pull request merged",
     className: "task-status--merged",
+  },
+  closed: {
+    badge: "Closed",
+    description: "PR closed",
+    className: "task-status--closed",
   },
   "other status": {
     badge: "Other status",


### PR DESCRIPTION
## Summary
- add the GitHub open and closed states to the recognised task status list so manual updates sync into history and notifications
- expose labels, default sound selections, and popup badge styling for the new statuses
- bump the extension version to 1.1.39 and record the change in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5195599d4833394abf97a40a3980d