### PR TITLE
Fix inconsistent PR status labels in history

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -91,7 +91,7 @@ const STATUS_DISPLAY = {
     className: "task-status--ready",
   },
   "pr-created": {
-    badge: "PR created",
+    badge: "PR ready to create",
     description: "PR ready to create",
     className: "task-status--pr-created",
   },
@@ -152,21 +152,13 @@ function normalizeStatusKey(value) {
   return String(value).trim().toLowerCase();
 }
 
-function titleCase(value) {
-  return value
-    .split(/\s+|-/)
-    .filter(Boolean)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join(" ");
-}
-
 function resolveStatusDisplay(statusKey) {
   const normalized = normalizeStatusKey(statusKey) || "working";
   const display = STATUS_DISPLAY[normalized];
   if (display) {
     return display;
   }
-  const fallback = titleCase(normalized);
+  const fallback = formatStatusLabel(normalized);
   return {
     badge: fallback,
     description: fallback,


### PR DESCRIPTION
## Summary
- align the history badge for the PR ready to create state with the renamed status text
- reuse the status label formatter when falling back so unknown history states render with consistent casing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e79fd095608333a4fc6ed0d547364a