### PR TITLE
Normalize history status display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 1.1.40 - 2025-10-02
+
+* **Fixed history status display:** Normalised stored status values so history
+  items always map to the correct badge and styling, even when the recorded
+  text contains spaces or punctuation.
+* **Version bumped to 1.1.40.**
+
 # 1.1.39 - 2025-10-02
 
 * **Support additional task statuses:** Expanded the recognised status list to

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/popup.js
+++ b/src/popup.js
@@ -149,7 +149,52 @@ function normalizeStatusKey(value) {
   if (!value) {
     return "";
   }
-  return String(value).trim().toLowerCase();
+
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+
+  if (Object.prototype.hasOwnProperty.call(STATUS_DISPLAY, normalized)) {
+    return normalized;
+  }
+
+  const simplified = normalized.replace(/[\s_-]+/g, " ").trim();
+
+  if (!simplified) {
+    return "";
+  }
+
+  if (/\bpr ready to view\b/.test(simplified) || simplified === "pr ready") {
+    return "pr-ready";
+  }
+
+  if (/\bpr ready to create\b/.test(simplified) || /\bpr created\b/.test(simplified)) {
+    return "pr-created";
+  }
+
+  if (/\btask ready to view\b/.test(simplified) || /\bready to view\b/.test(simplified) || simplified === "ready") {
+    return "ready";
+  }
+
+  if (/\bmerged\b/.test(simplified)) {
+    return "merged";
+  }
+
+  if (/\bclosed\b/.test(simplified)) {
+    return "closed";
+  }
+
+  if (/\bopen\b/.test(simplified)) {
+    return "open";
+  }
+
+  if (/\bworking\b/.test(simplified)) {
+    return "working";
+  }
+
+  const dashed = simplified.replace(/\s+/g, "-");
+  return dashed || normalized;
 }
 
 function titleCase(value) {
@@ -167,10 +212,18 @@ function resolveStatusDisplay(statusKey) {
     return display;
   }
   const fallback = titleCase(normalized);
+  const otherDisplay = STATUS_DISPLAY["other status"];
+  if (otherDisplay) {
+    return {
+      badge: fallback || otherDisplay.badge,
+      description: fallback || otherDisplay.description,
+      className: otherDisplay.className,
+    };
+  }
   return {
     badge: fallback,
     description: fallback,
-    className: "",
+    className: "task-status--other",
   };
 }
 


### PR DESCRIPTION
## Summary
- normalise history status values in the popup so strings with spaces or punctuation map to the correct badges
- fall back to the "Other status" styling for unknown history entries and document the fix in the changelog
- bump the extension version to 1.1.40

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7a2f6f2c08333822ec4351b847ed6