### PR TITLE
Handle Codex in-review updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 1.1.41 - 2025-10-02
+
+* **Keep history in sync with Codex:** Recognise the Codex "In Review" status
+  and persist it as an open pull request instead of prematurely flipping
+  tracked tasks to **PR ready**.
+* **Prevent premature PR ready promotion:** Skip the automatic PR ready update
+  when Codex has already advanced a task beyond the **PR created** state so the
+  stored history reflects the live status accurately.
+* **Version bumped to 1.1.41.**
+
 # 1.1.40 - 2025-10-02
 
 * **Fixed history status display:** Normalised stored status values so history

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.40",
+  "version": "1.1.41",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/background.js
+++ b/src/background.js
@@ -130,6 +130,10 @@ if (alarmsApi?.onAlarm && typeof alarmsApi.onAlarm.addListener === "function") {
     prReadyAlarmTasks.delete(alarm.name);
     const { id, name, url } = taskInfo;
     try {
+      const shouldPromote = await shouldAutoPromoteTaskToPrReady(id);
+      if (!shouldPromote) {
+        return;
+      }
       const completedAt = new Date().toISOString();
       // Persist and notify about the PR ready status. Because the alarm
       // fires independently of the original event page, always call
@@ -1602,6 +1606,26 @@ async function markTaskAsPrReady(task) {
   console.log("Marked Codex task as PR ready", updated);
 }
 
+async function shouldAutoPromoteTaskToPrReady(taskId) {
+  const id = normalizeTaskId(taskId);
+  if (!id) {
+    return false;
+  }
+
+  const history = (await storageGet(HISTORY_KEY)) ?? [];
+  if (!Array.isArray(history) || !history.length) {
+    return false;
+  }
+
+  const entry = history.find((item) => normalizeTaskId(item?.id) === id);
+  if (!entry) {
+    return false;
+  }
+
+  const status = String(entry?.status ?? "").trim().toLowerCase();
+  return status === "pr-created";
+}
+
 async function autoHandleReadyTask(task) {
   if (!task?.id || !task?.url) {
     return;
@@ -1676,25 +1700,36 @@ async function autoHandleReadyTask(task) {
           alarmsApi.create(alarmName, { when: Date.now() + PR_READY_DELAY_MS });
         } else {
           // Fallback: use setTimeout when alarms API is not available.
-        setTimeout(async () => {
-          const completedAtTimeout = new Date().toISOString();
-          await updateHistory({ id: task.id, status: "pr-ready", completedAt: completedAtTimeout });
-          await markTaskAsPrReady({ id: task.id, completedAt: completedAtTimeout });
-          if (notificationEnabledStatuses.has("pr-ready")) {
-            const prReadyTask = {
-              ...task,
+          setTimeout(async () => {
+            const shouldPromote = await shouldAutoPromoteTaskToPrReady(task.id);
+            if (!shouldPromote) {
+              return;
+            }
+            const completedAtTimeout = new Date().toISOString();
+            await updateHistory({
+              id: task.id,
               status: "pr-ready",
               completedAt: completedAtTimeout,
-            };
-            await showStatusNotification(prReadyTask, "pr-ready");
-          }
-          // Optionally close the Codex task tab if the user has enabled
-          // closing on PR ready. The content script will still handle
-          // clicking the "View PR" link within the existing page.
-          if (prReadyCloseTabEnabled) {
-            closeTaskTab(task.id);
-          }
-        }, PR_READY_DELAY_MS);
+            });
+            await markTaskAsPrReady({
+              id: task.id,
+              completedAt: completedAtTimeout,
+            });
+            if (notificationEnabledStatuses.has("pr-ready")) {
+              const prReadyTask = {
+                ...task,
+                status: "pr-ready",
+                completedAt: completedAtTimeout,
+              };
+              await showStatusNotification(prReadyTask, "pr-ready");
+            }
+            // Optionally close the Codex task tab if the user has enabled
+            // closing on PR ready. The content script will still handle
+            // clicking the "View PR" link within the existing page.
+            if (prReadyCloseTabEnabled) {
+              closeTaskTab(task.id);
+            }
+          }, PR_READY_DELAY_MS);
         }
       } catch (err) {
         console.error("Failed to schedule PR ready notification", err);

--- a/src/codexWatcher.js
+++ b/src/codexWatcher.js
@@ -223,6 +223,9 @@ function normalizeStatusLabel(label) {
   if (normalized.includes("closed")) {
     return "closed";
   }
+  if (normalized.includes("in review")) {
+    return "open";
+  }
   if (normalized.includes("open")) {
     return "open";
   }


### PR DESCRIPTION
## Summary
- recognize the Codex "In Review" announcement and persist it as an open status instead of promoting tasks to PR ready
- prevent the scheduled PR ready promotion from running when the stored status has already moved past PR created
- bump the extension version to 1.1.41 and document the changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7a8d858648333aa2f108f7c4f1e79