### PR TITLE
Update default popup color palette

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -179,9 +179,9 @@ const NOTIFICATION_POPUP_COLORS_STORAGE_KEY = "codexNotificationPopupColors";
 const DEFAULT_NOTIFICATION_POPUP_POSITION = { left: null, top: null };
 const DEFAULT_NOTIFICATION_POPUP_SIZE = { width: 360, height: 120 };
 const DEFAULT_NOTIFICATION_POPUP_COLORS = {
-  background: "#f7fafc",
-  page: "#ffffff",
-  text: "#1a1a1a",
+  background: "#4ade80",
+  page: "#000000",
+  text: "#ffffff",
 };
 let notificationPopupPosition = { ...DEFAULT_NOTIFICATION_POPUP_POSITION };
 let notificationPopupSize = { ...DEFAULT_NOTIFICATION_POPUP_SIZE };

--- a/src/options.html
+++ b/src/options.html
@@ -219,15 +219,30 @@
               <span class="popup-colour-heading">Popup colours:</span>
               <label class="popup-colour-option" for="popup-bg-color">
                 Button
-                <input type="color" id="popup-bg-color" name="popup-bg-color" />
+                <input
+                  type="color"
+                  id="popup-bg-color"
+                  name="popup-bg-color"
+                  value="#4ade80"
+                />
               </label>
               <label class="popup-colour-option" for="popup-page-color">
                 Background
-                <input type="color" id="popup-page-color" name="popup-page-color" />
+                <input
+                  type="color"
+                  id="popup-page-color"
+                  name="popup-page-color"
+                  value="#000000"
+                />
               </label>
               <label class="popup-colour-option" for="popup-text-color">
                 Text
-                <input type="color" id="popup-text-color" name="popup-text-color" />
+                <input
+                  type="color"
+                  id="popup-text-color"
+                  name="popup-text-color"
+                  value="#ffffff"
+                />
               </label>
             </div>
           </div>

--- a/src/options.js
+++ b/src/options.js
@@ -199,9 +199,9 @@ const NOTIFICATION_POPUP_COLORS_STORAGE_KEY = "codexNotificationPopupColors";
 const DEFAULT_NOTIFICATION_POPUP_POSITION = { left: null, top: null };
 const DEFAULT_NOTIFICATION_POPUP_SIZE = { width: 360, height: 120 };
 const DEFAULT_NOTIFICATION_POPUP_COLORS = {
-  background: "#f7fafc",
-  page: "#ffffff",
-  text: "#1a1a1a",
+  background: "#4ade80",
+  page: "#000000",
+  text: "#ffffff",
 };
 
 // Cached popup appearance values. These are populated from storage on


### PR DESCRIPTION
## Summary
- set the default notification popup colors to the new green button, black background, and white text palette
- seed the options page color pickers with the updated defaults so they appear active on load

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e7aae0ceac833382035690eb5ea231