### PR TITLE
Prioritize ready Codex statuses over merged badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 1.1.43 - 2025-10-03
+
+* **Keep ready tasks from masquerading as merged:** Continue scanning all
+  status badges on Codex task cards and favour "Task ready to view" and "PR
+  ready" indicators over "Merged" icons so automatic actions trigger and
+  history badges reflect the live state.
+* **Version bumped to 1.1.43.**
+
 # 1.1.42 - 2025-10-03
 
 * **Show closed tasks in history:** Capture Codex status badges on the task list

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.42",
+  "version": "1.1.43",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/codexWatcher.js
+++ b/src/codexWatcher.js
@@ -696,41 +696,72 @@ const STATUS_ATTRIBUTE_NAMES = [
   "data-state",
 ];
 const MAX_STATUS_TEXT_LENGTH = 160;
+const STATUS_PRIORITY = {
+  ready: 60,
+  "pr-ready": 50,
+  "pr-created": 40,
+  open: 30,
+  merged: 20,
+  closed: 10,
+  working: 5,
+};
+const HIGHEST_STATUS_PRIORITY = Math.max(0, ...Object.values(STATUS_PRIORITY));
+
+function getStatusPriority(status) {
+  if (!status) {
+    return 0;
+  }
+  return STATUS_PRIORITY[status] ?? 0;
+}
 
 function extractStatusFromElement(element, seenTexts) {
   if (!element) {
     return "";
   }
 
+  let bestStatus = "";
+  let bestPriority = 0;
+
+  const applyCandidate = (status) => {
+    if (!status) {
+      return;
+    }
+    const priority = getStatusPriority(status);
+    if (!bestStatus || priority > bestPriority) {
+      bestStatus = status;
+      bestPriority = priority;
+    }
+  };
+
   const considerText = (text) => {
     if (!text || typeof text !== "string") {
-      return "";
+      return;
     }
     const trimmed = text.replace(/\s+/g, " ").trim();
     if (!trimmed || trimmed.length > MAX_STATUS_TEXT_LENGTH) {
-      return "";
+      return;
     }
     if (seenTexts.has(trimmed)) {
-      return "";
+      return;
     }
     seenTexts.add(trimmed);
     const normalized = normalizeStatusLabel(trimmed);
     if (normalized) {
-      return normalized;
+      applyCandidate(normalized);
+      return;
     }
     const announcement = extractStatusFromAnnouncement(trimmed);
     if (announcement.status) {
-      return announcement.status;
+      applyCandidate(announcement.status);
     }
-    return "";
   };
 
   for (const attribute of STATUS_ATTRIBUTE_NAMES) {
     try {
       const value = element.getAttribute(attribute);
-      const result = considerText(value);
-      if (result) {
-        return result;
+      considerText(value);
+      if (bestPriority === HIGHEST_STATUS_PRIORITY) {
+        return bestStatus;
       }
     } catch (error) {
       // Ignore attribute access errors.
@@ -740,21 +771,18 @@ function extractStatusFromElement(element, seenTexts) {
   if (element.dataset) {
     const datasetValues = [element.dataset.status, element.dataset.state];
     for (const value of datasetValues) {
-      const result = considerText(value);
-      if (result) {
-        return result;
+      considerText(value);
+      if (bestPriority === HIGHEST_STATUS_PRIORITY) {
+        return bestStatus;
       }
     }
   }
 
   if (typeof element.textContent === "string") {
-    const result = considerText(element.textContent);
-    if (result) {
-      return result;
-    }
+    considerText(element.textContent);
   }
 
-  return "";
+  return bestStatus;
 }
 
 function extractStatusFromContainer(container, link) {
@@ -763,6 +791,19 @@ function extractStatusFromContainer(container, link) {
   }
 
   const seenTexts = new Set();
+  let bestStatus = "";
+  let bestPriority = 0;
+
+  const applyCandidate = (status) => {
+    if (!status) {
+      return;
+    }
+    const priority = getStatusPriority(status);
+    if (!bestStatus || priority > bestPriority) {
+      bestStatus = status;
+      bestPriority = priority;
+    }
+  };
 
   const candidates = new Set();
   for (const selector of STATUS_ELEMENT_SELECTORS) {
@@ -778,8 +819,9 @@ function extractStatusFromContainer(container, link) {
       }
       candidates.add(element);
       const status = extractStatusFromElement(element, seenTexts);
-      if (status) {
-        return status;
+      applyCandidate(status);
+      if (bestPriority === HIGHEST_STATUS_PRIORITY) {
+        return bestStatus;
       }
     }
   }
@@ -790,12 +832,13 @@ function extractStatusFromContainer(container, link) {
       continue;
     }
     const status = extractStatusFromElement(element, seenTexts);
-    if (status) {
-      return status;
+    applyCandidate(status);
+    if (bestPriority === HIGHEST_STATUS_PRIORITY) {
+      return bestStatus;
     }
   }
 
-  return "";
+  return bestStatus;
 }
 
 function notifyBackground(task) {


### PR DESCRIPTION
## Summary
- ensure Codex status extraction checks every badge on a task card before returning
- prioritise ready and PR-ready statuses ahead of merged icons so automation and history stay in sync
- bump the extension version to 1.1.43 and record the change in the changelog

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7b9ade7888333b4dd575214312f42