### PR TITLE
Remove history status descriptions from popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.1.44 - 2025-10-03
+
+* **Hide status descriptions in history:** Remove the secondary status label
+  text so task history entries only display the primary status badge.
+* **Version bumped to 1.1.44.**
+
 # 1.1.43 - 2025-10-03
 
 * **Keep ready tasks from masquerading as merged:** Continue scanning all

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "codex-autorun",
-  "version": "1.1.43",
+  "version": "1.1.44",
   "description": "The codex-autorun WebExtension with background script and popup.",
   "permissions": [
     "storage",

--- a/src/popup.js
+++ b/src/popup.js
@@ -941,13 +941,6 @@ function renderHistory(history) {
     statusBadge.textContent = statusDisplay.badge;
     statusContainer.append(statusBadge);
 
-    if (statusDisplay.description) {
-      const statusLabel = document.createElement("span");
-      statusLabel.className = "task-status-label";
-      statusLabel.textContent = statusDisplay.description;
-      statusContainer.append(statusLabel);
-    }
-
     meta.append(idBadge, startedTime, statusContainer);
     content.append(meta);
     item.append(content);


### PR DESCRIPTION
## Summary
- stop rendering the secondary status description text in the popup history so only the badge shows
- bump the extension version to 1.1.44 and document the change in the changelog

## Testing
- not run (extension)


------
https://chatgpt.com/codex/tasks/task_e_68e7de4a6c58833391ed48e98ff67b5c