### PR TITLE
Hide metadata in task history list

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -118,18 +118,15 @@ button:disabled {
 
 
 .history-item {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  padding: 0.5rem;
-  border-radius: 0.5rem;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
+  display: block;
+  padding: 0;
+  border: 0;
+  background: none;
 }
 
 .history-item:hover {
-  border-color: #cbd5f5;
-  background: #eef2ff;
+  border: 0;
+  background: none;
 }
 
 .task-name {
@@ -143,93 +140,26 @@ button:disabled {
 }
 
 .task-content {
-  flex: 1 1 60%;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+  display: block;
 }
 
 .task-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  display: block;
 }
 
 .task-close {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  padding: 0;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: transparent;
-  color: #dc2626;
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 1;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.task-close:hover:not(:disabled) {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.task-close:active:not(:disabled) {
-  transform: scale(0.95);
-}
-
-.task-close:focus-visible {
-  outline: 2px solid #dc2626;
-  outline-offset: 2px;
-}
-
-.task-close:disabled {
-  opacity: 0.6;
-  cursor: wait;
+  display: none;
 }
 
 .task-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  font-size: 0.75rem;
-  color: #475569;
+  display: none;
 }
 
-.task-id {
-  padding: 0.1rem 0.4rem;
-  border-radius: 0.375rem;
-  background: #ede9fe;
-  color: #5b21b6;
-  font-weight: 500;
-}
-
-.task-status {
-  padding: 0.1rem 0.4rem;
-  border-radius: 0.375rem;
-  background: #dcfce7;
-  color: #166534;
-  font-weight: 600;
-  text-transform: none;
-  letter-spacing: normal;
-}
-
-.task-status-container {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
+.task-id,
+.task-status,
+.task-status-container,
 .task-status-label {
-  font-weight: 500;
-  color: #334155;
+  display: none;
 }
 
 .task-status--ready {
@@ -273,26 +203,13 @@ button:disabled {
 }
 
 .task-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  margin-left: auto;
+  display: none;
 }
 
-.task-action {
-  font-size: 0.8rem;
-  padding: 0.35rem 0.6rem;
-}
-
-.task-action.view-task {
-  border-color: #94a3b8;
-  background: #e2e8f0;
-  color: #1f2937;
-}
-
+.task-action,
+.task-action.view-task,
 .task-action.view-task:hover:not(:disabled) {
-  background: #cbd5f5;
-  border-color: #94a3b8;
+  display: none;
 }
 
 #error {


### PR DESCRIPTION
## Summary
- hide task metadata, status badges, and action buttons in the popup history
- simplify the history item layout so only the task name remains visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7ef787f888333a408623b86ebb9bf